### PR TITLE
Adds support for v1 of the tls-certificates interface

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,10 @@ options:
     type: boolean
     default: false
     description: Generate self-signed certificates and ignores provided certificates.
+  ca-common-name:
+    type: string
+    default:
+    description: Common name to be used only if `generate-self-signed-certificates` set to true.
   certificate:
     type: string
     default:

--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -1,0 +1,851 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the tls-certificates relation.
+
+This library contains the Requires and Provides classes for handling the tls-certificates
+interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.tls_certificates_interface.v1.tls_certificates
+```
+
+Add the following library to the charm's `requirements.txt` file:
+- jsonschema
+- cryptography
+
+Add the following section to the charm's `charmcraft.yaml` file:
+```yaml
+parts:
+  charm:
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
+```
+
+### Provider charm
+The provider charm is the charm providing certificates to another charm that requires them. In
+this example, the provider charm is storing its private key using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateRequestEvent,
+    TLSCertificatesProvides,
+    generate_private_key,
+)
+from ops.charm import CharmBase, InstallEvent
+from ops.model import ActiveStatus, WaitingStatus
+
+
+def generate_ca(private_key: bytes, subject: str) -> str:
+    return "whatever ca content"
+
+
+def generate_certificate(ca: str, private_key: str, csr: str) -> str:
+    return "Whatever certificate"
+
+
+class ExampleProviderCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificates = TLSCertificatesProvides(self, "certificates")
+        self.framework.observe(
+            self.certificates.on.certificate_request, self._on_certificate_request
+        )
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event: InstallEvent) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        ca_certificate = generate_ca(private_key=private_key, subject="whatever")
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {
+                "private_key_password": "banana",
+                "private_key": private_key,
+                "ca_certificate": ca_certificate,
+            }
+        )
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_request(self, event: CertificateRequestEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        ca_certificate = replicas_relation.data[self.app].get("ca_certificate")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        certificate = generate_certificate(
+            ca=ca_certificate,
+            private_key=private_key,
+            csr=event.certificate_signing_request,
+        )
+
+        self.certificates.set_relation_certificate(
+            certificate=certificate,
+            certificate_signing_request=event.certificate_signing_request,
+            ca=ca_certificate,
+            chain=ca_certificate,
+            relation_id=event.relation_id,
+        )
+
+
+if __name__ == "__main__":
+    main(ExampleProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them. In
+this example, the requirer charm is storing its certificates using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateAvailableEvent,
+    CertificateExpiringEvent,
+    TLSCertificatesRequires,
+    generate_csr,
+    generate_private_key,
+)
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.model import ActiveStatus, WaitingStatus
+
+
+class ExampleRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificates = TLSCertificatesRequires(self, "certificates")
+        self.framework.observe(
+            self.certificates.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {"private_key_password": "banana", "private_key": private_key.decode()}
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject="whatever",
+        )
+        replicas_relation.data[self.app].update({"csr": csr.decode()})
+        self.certificates.request_certificate(csr=csr)
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update({"certificate": event.certificate})
+        replicas_relation.data[self.app].update({"ca": event.ca})
+        replicas_relation.data[self.app].update({"chain": event.chain})
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_almost_expired(self, event: CertificateExpiringEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        new_csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject="whatever",
+        )
+        self.certificates.request_certificate(csr=new_csr)
+        existing_csr = replicas_relation.data[self.app].get("csr")
+        self.certificates.revoke_certificate(certificate_signing_request=existing_csr.encode())
+        replicas_relation.data[self.app].update({"csr": new_csr.decode()})
+
+
+if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+"""  # noqa: D405, D410, D411, D214, D416
+
+import json
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jsonschema import exceptions, validate  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, UpdateStatusEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "afd8c2bccf834997afce12c2706d2ede"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 0
+
+REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v1/schemas/requirer.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` requirer root schema",
+    "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
+    "examples": [
+        {
+            "certificate_signing_requests": [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBAMk3raaX803cHvzlBF9LC7KORT46z4VjyU5PIaMb\\nQLIDgYKFYI0n5hf2Ra4FAHvOvEmW7bjNlHORFEmvnpcU5kPMNUyKFMTaC8LGmN8z\\nUBH3aK+0+FRvY4afn9tgj5435WqOG9QdoDJ0TJkjJbJI9M70UOgL711oU7ql6HxU\\n4d2ydFK9xAHrBwziNHgNZ72L95s4gLTXf0fAHYf15mDA9U5yc+YDubCKgTXzVySQ\\nUx73VCJLfC/XkZIh559IrnRv5G9fu6BMLEuBwAz6QAO4+/XidbKWN4r2XSq5qX4n\\n6EPQQWP8/nd4myq1kbg6Q8w68L/0YdfjCmbyf2TuoWeImdUCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQBIdwraBvpYo/rl5MH1+1Um6HRg4gOdQPY5WcJy9B9tgzJz\\nittRSlRGTnhyIo6fHgq9KHrmUthNe8mMTDailKFeaqkVNVvk7l0d1/B90Kz6OfmD\\nxN0qjW53oP7y3QB5FFBM8DjqjmUnz5UePKoX4AKkDyrKWxMwGX5RoET8c/y0y9jp\\nvSq3Wh5UpaZdWbe1oVY8CqMVUEVQL2DPjtopxXFz2qACwsXkQZxWmjvZnRiP8nP8\\nbdFaEuh9Q6rZ2QdZDEtrU4AodPU3NaukFr5KlTUQt3w/cl+5//zils6G5zUWJ2pN\\ng7+t9PTvXHRkH+LnwaVnmsBFU2e05qADQbfIn7JA\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+            ]
+        }
+    ],
+    "properties": {
+        "certificate_signing_requests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"certificate_signing_request": {"type": "string"}},
+                "required": ["certificate_signing_request"],
+            },
+        }
+    },
+    "required": ["certificate_signing_requests"],
+    "additionalProperties": True,
+}
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v1/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` provider root schema",
+    "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
+    "example": [
+        {
+            "certificates": [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "chain": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\n-----END CERTIFICATE REQUEST-----\n",  # noqa: E501
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+                }
+            ]
+        }
+    ],
+    "properties": {
+        "certificates": {
+            "$id": "#/properties/certificates",
+            "type": "array",
+            "items": {
+                "$id": "#/properties/certificates/items",
+                "type": "object",
+                "required": ["certificate_signing_request", "certificate", "ca", "chain"],
+                "properties": {
+                    "certificate_signing_request": {
+                        "$id": "#/properties/certificates/items/certificate_signing_request",
+                        "type": "string",
+                    },
+                    "certificate": {
+                        "$id": "#/properties/certificates/items/certificate",
+                        "type": "string",
+                    },
+                    "ca": {"$id": "#/properties/certificates/items/ca", "type": "string"},
+                    "chain": {"$id": "#/properties/certificates/items/chain", "type": "string"},
+                },
+            },
+        }
+    },
+    "required": ["certificates"],
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: str,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+class CertificateExpiringEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is almost expired."""
+
+    def __init__(self, handle, certificate: str, expiry: datetime):
+        """CertificateExpiringEvent.
+
+        Args:
+            handle (Handle): Juju framework handle
+            certificate (str): TLS Certificate
+            expiry (datetime): Datetime object reprensenting the time at which the certificate
+                won't be valid anymore.
+        """
+        super().__init__(handle)
+        self.certificate = certificate
+        self.expiry = expiry
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {"certificate": self.certificate, "expiry": self.expiry}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.expiry = snapshot["expiry"]
+
+
+class CertificateExpiredEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is expired."""
+
+    def __init__(self, handle: Handle, certificate: str):
+        super().__init__(handle)
+        self.certificate = certificate
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {"certificate": self.certificate}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+
+
+class CertificateRequestEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is required."""
+
+    def __init__(self, handle: Handle, certificate_signing_request: str, relation_id: int):
+        super().__init__(handle)
+        self.certificate_signing_request = certificate_signing_request
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate_signing_request": self.certificate_signing_request,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateRevokalEvent(EventBase):
+    """Charm Event triggered when a TLS certificate needs to be revoked."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: str,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+def load_unit_relation_data(raw_relation_data: dict) -> dict:
+    """Loads relation data from the relation data bag.
+
+    Json loads all data.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    certificate_data = dict()
+    for key in raw_relation_data:
+        try:
+            certificate_data[key] = json.loads(raw_relation_data[key])
+        except json.decoder.JSONDecodeError:
+            certificate_data[key] = raw_relation_data[key]
+    return certificate_data
+
+
+def generate_private_key(
+    password: Optional[bytes] = None,
+    key_size: int = 2048,
+    public_exponent: int = 65537,
+) -> bytes:
+    """Generates a private key.
+
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
+
+    Returns:
+        bytes: Private Key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.BestAvailableEncryption(password)
+        if password
+        else serialization.NoEncryption(),
+    )
+    return key_bytes
+
+
+def generate_csr(
+    private_key: bytes,
+    subject: str,
+    private_key_password: Optional[bytes] = None,
+    sans: Optional[List[str]] = None,
+    additional_critical_extensions: Optional[List] = None,
+) -> bytes:
+    """Generates a CSR using private key and subject.
+
+    Args:
+        private_key (bytes): Private key
+        private_key_password (bytes): Private key password
+        subject (str): CSR Subject.
+        sans (list): List of subject alternative names
+        additional_critical_extensions (list): List if critical additional extension objects.
+            Object must be a x509 ExtensionType.
+
+    Returns:
+        bytes: CSR
+    """
+    signing_key = serialization.load_pem_private_key(private_key, password=private_key_password)
+    csr = x509.CertificateSigningRequestBuilder(
+        subject_name=x509.Name(
+            [
+                x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
+            ]
+        )
+    )
+    if sans:
+        csr = csr.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
+        )
+    if additional_critical_extensions:
+        for extension in additional_critical_extensions:
+            csr = csr.add_extension(extension, critical=True)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    return signed_certificate.public_bytes(serialization.Encoding.PEM)
+
+
+class CertificatesProviderCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates provider charm can leverage."""
+
+    certificate_request = EventSource(CertificateRequestEvent)
+    certificate_revokal = EventSource(CertificateRevokalEvent)
+
+
+class CertificatesRequirerCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+    certificate_expiring = EventSource(CertificateExpiringEvent)
+    certificate_expired = EventSource(CertificateExpiredEvent)
+
+
+class TLSCertificatesProvidesV1(Object):
+    """TLS certificates provider class to be instantiated by TLS certificates providers."""
+
+    on = CertificatesProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Uses JSON schema validator to validate relation data content.
+
+        Args:
+            certificates_data (dict): Certificate data dictionary as retrieved from relation data.
+
+        Returns:
+            bool: True/False depending on whether the relation data follows the json schema.
+        """
+        try:
+            validate(instance=certificates_data, schema=REQUIRER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def set_relation_certificate(
+        self,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: str,
+        relation_id: int,
+    ) -> None:
+        """Adds certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            certificate_signing_request (str): Certificate signing request
+            ca (str): CA Certificate
+            chain (str): CA Chain certificate
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        relation_data = certificates_relation.data[self.model.unit]  # type: ignore[union-attr]
+        loaded_relation_data = load_unit_relation_data(relation_data)
+        new_certificate = {
+            "certificate": certificate,
+            "certificate_signing_request": certificate_signing_request,
+            "ca": ca,
+            "chain": chain,
+        }
+        if "certificates" not in loaded_relation_data:
+            certificates = [new_certificate]
+        else:
+            certificates = loaded_relation_data["certificates"]
+            for i in range(len(certificates)):
+                if certificates[i]["certificate_signing_request"] == certificate_signing_request:
+                    certificates.pop(i)
+            loaded_relation_data["certificates"].append(new_certificate)
+
+        relation_data["certificates"] = json.dumps(certificates)
+
+    def _on_relation_changed(self, event) -> None:
+        """Handler triggerred on relation changed event.
+
+        Looks at the relation data and either emits:
+        - certificate request event: If the unit relation data contains a CSR for which
+            a certificate does not exist in the provider relation data.
+        - certificate revokal event: If the provider relation data contains a CSR for which
+            a csr does not exist in the requirer relation data.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        requirer_relation_data = load_unit_relation_data(event.relation.data[event.unit])
+        provider_relation_data = load_unit_relation_data(event.relation.data[self.model.unit])
+        if not self._relation_data_is_valid(requirer_relation_data):
+            logger.warning("Relation data did not pass JSON Schema validation")
+            return
+        provider_csrs = self._get_provider_csrs(event.relation.data[self.model.unit])
+        requirer_csrs = self._get_requirer_csrs(event.relation.data[event.unit])
+        for certificate_signing_request in requirer_csrs:
+            if certificate_signing_request not in provider_csrs:
+                self.on.certificate_request.emit(
+                    certificate_signing_request=certificate_signing_request,
+                    relation_id=event.relation.id,
+                )
+        for certificate in provider_relation_data.get("certificates", []):
+            if certificate["certificate_signing_request"] not in requirer_csrs:
+                self.on.certificate_revokal.emit(
+                    certificate=certificate["certificate"],
+                    certificate_signing_request=certificate["certificate_signing_request"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                )
+
+    @staticmethod
+    def _get_requirer_csrs(raw_requirer_unit_relation_data: dict) -> List[str]:
+        requirer_relation_data = load_unit_relation_data(raw_requirer_unit_relation_data)
+        return [
+            certificate_request["certificate_signing_request"]
+            for certificate_request in requirer_relation_data.get(
+                "certificate_signing_requests", []
+            )
+            if certificate_request.get("certificate_signing_request", None)
+        ]
+
+    @staticmethod
+    def _get_provider_csrs(raw_provider_unit_relation_data: dict) -> List[str]:
+        provider_relation_data = load_unit_relation_data(raw_provider_unit_relation_data)
+        return [
+            certificate["certificate_signing_request"]
+            for certificate in provider_relation_data.get("certificates", [])
+            if certificate.get("certificate_signing_request", None)
+        ]
+
+
+class TLSCertificatesRequires(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = CertificatesRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+        expiry_notification_time: int = 168,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+            expiry_notification_time (int): Time difference between now and expiry. Used to
+                trigger the CertificateExpiring event.
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.expiry_notification_time = expiry_notification_time
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(charm.on.update_status, self._on_update_status)
+
+    def request_certificate(self, csr: bytes) -> None:
+        """Request TLS certificate to provider charm.
+
+        Args:
+            csr (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        logger.info("Received request to create certificate")
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            message = (
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+            logger.error(message)
+            raise RuntimeError(message)
+        relation_data = load_unit_relation_data(relation.data[self.model.unit])
+        new_certificate_request = {"certificate_signing_request": csr.decode()}
+        if "certificate_signing_requests" in relation_data:
+            certificate_request_list = relation_data["certificate_signing_requests"]
+            if new_certificate_request in certificate_request_list:
+                logger.info("Request was already made - Doing nothing")
+                return
+            certificate_request_list.append(new_certificate_request)
+        else:
+            certificate_request_list = [new_certificate_request]
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            certificate_request_list
+        )
+        logger.info("Certificate request sent to provider")
+
+    def renew_certificate(self, certificate_signing_request: bytes) -> None:
+        """Renews Certificate.
+
+        Revokes certificate than requests one with the same CSR.
+
+        Args:
+            certificate_signing_request:
+
+        Returns:
+            None
+        """
+        self.revoke_certificate(certificate_signing_request)
+        self.request_certificate(certificate_signing_request)
+
+    def revoke_certificate(self, certificate_signing_request: bytes) -> None:
+        """Removes CSR from relation data.
+
+        The provider of this relation is then expected to remove certificates associated to this
+        CSR from the relation data as well and emit a revoke_certificate event for the provider
+        charm to interpret.
+
+        Args:
+            certificate_signing_request (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        relation_data = load_unit_relation_data(relation.data[self.model.unit])
+        certificate_request_list = relation_data.get("certificate_signing_requests")
+        if not certificate_request_list:
+            logger.info("No CSR in relation data.")
+            return
+        for i in range(len(certificate_request_list)):
+            if (
+                certificate_request_list[i]["certificate_signing_request"]
+                == certificate_signing_request.decode()
+            ):
+                certificate_request_list.pop()
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            certificate_request_list
+        )
+        logger.info("Certificate revocation sent to provider")
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Checks whether relation data is valid based on json schema.
+
+        Args:
+            certificates_data: Certificate data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggerred on relation changed events.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        relation_data = load_unit_relation_data(event.relation.data[event.unit])
+        if not relation_data:
+            logger.info("No relation data")
+            return
+        if not self._relation_data_is_valid(relation_data):
+            logger.warning("Relation data did not pass JSON Schema validation")
+            return
+        for certificate in relation_data["certificates"]:
+            self.on.certificate_available.emit(
+                certificate_signing_request=certificate["certificate_signing_request"],
+                certificate=certificate["certificate"],
+                ca=certificate["ca"],
+                chain=certificate["chain"],
+            )
+
+    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+        """Triggered on update status event.
+
+        Goes through each certificate in the "certificates" relation and checks their expiry date.
+        If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
+        they are expired, emits a CertificateExpiredEvent.
+
+        Args:
+            event (UpdateStatusEvent): Juju event
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation("certificates")
+        if not relation:
+            return
+        for unit in relation.units:
+            relation_data = load_unit_relation_data(relation.data[unit])
+            if self._relation_data_is_valid(relation_data):
+                certificates = relation_data.get("certificates")
+                if not certificates:
+                    continue
+                for certificate_dict in certificates:
+                    certificate = certificate_dict["certificate"]
+                    certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+                    time_difference = certificate_object.not_valid_after - datetime.utcnow()
+                    if time_difference.total_seconds() < 0:
+                        logger.warning("Certificate is expired")
+                        self.on.certificate_expired.emit(certificate=certificate)
+                        self.revoke_certificate(certificate)
+                        continue
+                    if time_difference.total_seconds() < (self.expiry_notification_time * 60 * 60):
+                        logger.info("Certificate almost expired")
+                        self.on.certificate_expiring.emit(
+                            certificate=certificate, expiry=certificate_object.not_valid_after
+                        )

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,18 +10,35 @@ Certificates are provided by the operator trough Juju configs.
 import base64
 import binascii
 import logging
-from typing import List
+import secrets
+import string
+from typing import List, Tuple
 
+from charms.tls_certificates_interface.v0.tls_certificates import Cert as CertV0
 from charms.tls_certificates_interface.v0.tls_certificates import (
-    Cert,
-    CertificateRequestEvent,
-    TLSCertificatesProvides,
+    CertificateRequestEvent as CertificateRequestEventV0,
+)
+from charms.tls_certificates_interface.v0.tls_certificates import (
+    TLSCertificatesProvides as TLSCertificatesProvidesV0,
+)
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateRequestEvent as CertificateRequestEventV1,
+)
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    TLSCertificatesProvidesV1,
 )
 from ops.charm import CharmBase, ConfigChangedEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from self_signed_certificates import Certificate, PrivateKey, SelfSignedCertificates
+from self_signed_certificates import (
+    certificate_is_valid,
+    generate_ca,
+    generate_certificate,
+    generate_csr,
+    generate_private_key,
+    private_key_is_valid,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +49,48 @@ class TLSCertificatesOperatorCharm(CharmBase):
     def __init__(self, *args):
         """Observes config change and certificate request events."""
         super().__init__(*args)
-        self.tls_certificates = TLSCertificatesProvides(self, "certificates")
+        self.tls_certificates_v0 = TLSCertificatesProvidesV0(self, "certificates")
+        self.tls_certificates_v1 = TLSCertificatesProvidesV1(self, "certificates")
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
-            self.tls_certificates.on.certificate_request, self._on_certificate_request
+            self.tls_certificates_v0.on.certificate_request, self._on_certificate_request_v0
+        )
+        self.framework.observe(
+            self.tls_certificates_v1.on.certificate_request, self._on_certificate_request_v1
         )
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+
+    def _on_install(self, event):
+        if not self._self_signed_certificates:
+            return
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        self._generate_root_certificates()
+
+    def _generate_root_certificates(self) -> None:
+        """Generates root certificate to be used to sign certificates.
+
+        Returns:
+            None
+        """
+        replicas_relation = self.model.get_relation("replicas")
+        private_key_password = self._generate_password()
+        private_key = generate_private_key(password=private_key_password.encode())
+        ca_certificate = generate_ca(
+            private_key=private_key,
+            subject=self.model.config.get("ca-common-name"),  # type: ignore[arg-type]  # noqa: E501
+            private_key_password=private_key_password.encode(),
+        )
+        replicas_relation.data[self.app].update(  # type: ignore[union-attr]
+            {
+                "ca_private_key_password": private_key_password,
+                "ca_private_key": private_key.decode(),
+                "ca_certificate": ca_certificate.decode(),
+            }
+        )
 
     @property
     def _self_signed_certificates(self) -> bool:
@@ -45,7 +99,9 @@ class TLSCertificatesOperatorCharm(CharmBase):
         Returns:
             bool: True/False
         """
-        if self.model.config.get("generate-self-signed-certificates", False):
+        if self.model.config.get(
+            "generate-self-signed-certificates", False
+        ) and self.model.config.get("ca-common-name", False):
             return True
         else:
             return False
@@ -63,11 +119,13 @@ class TLSCertificatesOperatorCharm(CharmBase):
             private_key_bytes = base64.b64decode(self.model.config.get("private-key"))  # type: ignore[arg-type]  # noqa: E501
         except binascii.Error:
             return False
-
-        certificate = Certificate(certificate_bytes)
-        ca_certificate = Certificate(ca_certificate_bytes)
-        private_key = PrivateKey(private_key_bytes)
-        return certificate.is_valid and ca_certificate.is_valid and private_key.is_valid
+        try:
+            assert certificate_is_valid(certificate_bytes)
+            assert certificate_is_valid(ca_certificate_bytes)
+            assert private_key_is_valid(private_key_bytes)
+            return True
+        except AssertionError:
+            return False
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Triggered once when the charm is installed.
@@ -113,36 +171,47 @@ class TLSCertificatesOperatorCharm(CharmBase):
                 )
         self.unit.status = ActiveStatus()
 
-    def _generate_self_signed_certificates(self, common_name: str) -> None:
-        """Generates self-signed certificates and stores them.
+    def _generate_self_signed_certificates_v0(self, common_name: str) -> Tuple[str, str]:
+        """Generates self-signed certificates.
 
         Args:
             common_name (str): Certificate common name (used for subject)
 
         Returns:
-            None
+            (str, str): Certificate and Private Key
         """
-        if not self.unit.is_leader():
-            return
-        self_signed_certificates = SelfSignedCertificates()
-        self_signed_certificates.generate(common_name=common_name)
-        replicas = self.model.get_relation("replicas")
-        replicas.data[self.app].update(  # type: ignore[union-attr]
-            {
-                "ca_certificate": self._decode_from_base64_bytes(
-                    self_signed_certificates.ca_certificate
-                )
-            }
-        )
-        replicas.data[self.app].update(  # type: ignore[union-attr]
-            {"certificate": self._decode_from_base64_bytes(self_signed_certificates.certificate)}
-        )
-        replicas.data[self.app].update(  # type: ignore[union-attr]
-            {"private_key": self._decode_from_base64_bytes(self_signed_certificates.private_key)}
+        replicas_relation = self.model.get_relation("replicas")
+        ca_certificate = replicas_relation.data[self.app].get("ca_certificate")  # type: ignore[union-attr]  # noqa: E501
+        ca_private_key = replicas_relation.data[self.app].get("ca_private_key")  # type: ignore[union-attr]  # noqa: E501
+        private_key = generate_private_key()
+        csr = generate_csr(private_key=ca_private_key, subject=common_name)
+        certificate = generate_certificate(
+            ca=ca_certificate.encode(), ca_key=ca_private_key.encode(), csr=csr
         )
         logger.info("Generated self-signed certificates")
+        return certificate.decode(), private_key.decode()
 
-    def _on_certificate_request(self, event: CertificateRequestEvent) -> None:
+    def _generate_self_signed_certificates_v1(self, certificate_signing_request: str) -> str:
+        """Generates self-signed certificates.
+
+        Args:
+            certificate_signing_request (str): Certificate signing request
+
+        Returns:
+            str: Certificate
+        """
+        replicas_relation = self.model.get_relation("replicas")
+        ca_certificate = replicas_relation.data[self.app].get("ca_certificate")  # type: ignore[union-attr]  # noqa: E501
+        ca_private_key = replicas_relation.data[self.app].get("ca_private_key")  # type: ignore[union-attr]  # noqa: E501
+        certificate = generate_certificate(
+            ca=ca_certificate.encode(),
+            ca_key=ca_private_key,
+            csr=certificate_signing_request.encode(),
+        )
+        logger.info("Generated self-signed certificates")
+        return certificate.decode()
+
+    def _on_certificate_request_v0(self, event: CertificateRequestEventV0) -> None:
         """Triggered everytime there's a certificate request.
 
         Args:
@@ -153,29 +222,82 @@ class TLSCertificatesOperatorCharm(CharmBase):
         """
         if not self.unit.is_leader():
             return
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
         if self._self_signed_certificates:
-            if not self._certificates_are_set:
-                self._generate_self_signed_certificates(event.common_name)
+            if not self._root_certificates_are_set:
+                event.defer()
+                return
+            certificate, private_key = self._generate_self_signed_certificates_v0(
+                event.common_name
+            )
+            self.tls_certificates_v0.set_relation_certificate(
+                certificate=CertV0(
+                    cert=certificate,
+                    key=private_key,
+                    ca=replicas_relation.data[self.app].get("ca_certificate"),
+                    common_name=event.common_name,
+                ),
+                relation_id=event.relation_id,
+            )
         else:
-            if not self._certificates_are_set:
+            if not self._config_certificates_are_set:
                 logger.error(
                     "Configuration options are missing - "
                     "Certificates can't be passed through relation"
                 )
                 return
-        replicas = self.model.get_relation("replicas")
-        self.tls_certificates.set_relation_certificate(
-            certificate=Cert(
-                cert=replicas.data[self.app].get("certificate"),  # type: ignore[union-attr]
-                key=replicas.data[self.app].get("private_key"),  # type: ignore[union-attr]
-                ca=replicas.data[self.app].get("ca_certificate"),  # type: ignore[union-attr]
-                common_name=event.common_name,
-            ),
-            relation_id=event.relation_id,
-        )
+            self.tls_certificates_v0.set_relation_certificate(
+                certificate=CertV0(
+                    cert=replicas_relation.data[self.app].get("certificate"),
+                    key=replicas_relation.data[self.app].get("private_key"),
+                    ca=replicas_relation.data[self.app].get("ca_certificate"),
+                    common_name=event.common_name,
+                ),
+                relation_id=event.relation_id,
+            )
+
+    def _on_certificate_request_v1(self, event: CertificateRequestEventV1):
+        if not self.unit.is_leader():
+            return
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        if self._self_signed_certificates:
+            if not self._root_certificates_are_set:
+                certificate = self._generate_self_signed_certificates_v1(
+                    event.certificate_signing_request
+                )
+                self.tls_certificates_v1.set_relation_certificate(
+                    certificate_signing_request=event.certificate_signing_request,
+                    certificate=certificate,
+                    ca=replicas_relation.data[self.app].get("ca_certificate"),
+                    chain=replicas_relation.data[self.app].get("ca_certificate"),
+                    relation_id=event.relation_id,
+                )
+        else:
+            if not self._config_certificates_are_set:
+                logger.error(
+                    "Configuration options are missing - "
+                    "Certificates can't be passed through relation"
+                )
+                return
+
+            self.tls_certificates_v1.set_relation_certificate(
+                certificate_signing_request=event.certificate_signing_request,
+                certificate=replicas_relation.data[self.app].get("certificate"),
+                ca=replicas_relation.data[self.app].get("ca_certificate"),
+                chain=replicas_relation.data[self.app].get("ca_certificate"),
+                relation_id=event.relation_id,
+            )
 
     @property
-    def _certificates_are_set(self) -> bool:
+    def _config_certificates_are_set(self) -> bool:
         """Returns whether certificates are set in stored data.
 
         Returns:
@@ -186,6 +308,20 @@ class TLSCertificatesOperatorCharm(CharmBase):
             replicas.data[self.app].get("certificate")  # type: ignore[union-attr]  # noqa: W503 E501
             and replicas.data[self.app].get("ca_certificate")  # type: ignore[union-attr]  # noqa: W503 E501
             and replicas.data[self.app].get("private_key")  # type: ignore[union-attr]  # noqa: W503 E501
+        )
+
+    @property
+    def _root_certificates_are_set(self) -> bool:
+        """Returns whether certificates are set in stored data.
+
+        Returns:
+            bool: Whether all certificates are set.
+        """
+        replicas = self.model.get_relation("replicas")
+        return (
+            replicas.data[self.app].get("ca_private_key")  # type: ignore[union-attr]  # noqa: W503 E501
+            and replicas.data[self.app].get("ca_certificate")  # type: ignore[union-attr]  # noqa: W503 E501
+            and replicas.data[self.app].get("ca_private_key_password")  # type: ignore[union-attr]  # noqa: W503 E501
         )
 
     def get_missing_configuration_options(self) -> List[str]:
@@ -216,6 +352,16 @@ class TLSCertificatesOperatorCharm(CharmBase):
             str: String
         """
         return bytes_content.decode("utf-8")
+
+    @staticmethod
+    def _generate_password() -> str:
+        """Generates a random 12 character password.
+
+        Returns:
+            str: Password
+        """
+        chars = string.ascii_letters + string.digits
+        return "".join(secrets.choice(chars) for _ in range(12))
 
 
 if __name__ == "__main__":

--- a/src/self_signed_certificates.py
+++ b/src/self_signed_certificates.py
@@ -5,268 +5,208 @@
 """Methods used to generate self-signed certificates."""
 
 import datetime
+from typing import List, Optional
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-class SelfSignedCertificates:
-    """Class that contains logic to generate and store self-signed certificates."""
+def generate_private_key(
+    password: Optional[bytes] = None,
+    key_size: int = 2048,
+    public_exponent: int = 65537,
+) -> bytes:
+    """Generates a private key.
 
-    def __init__(self):
-        """Initializes stored certificates to empty bytes."""
-        self._private_key = bytes()
-        self._ca_certificate = bytes()
-        self._certificate = bytes()
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
 
-    @property
-    def private_key(self) -> bytes:
-        """Returns the stored private key.
+    Returns:
+        bytes: Private Key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.BestAvailableEncryption(password)
+        if password
+        else serialization.NoEncryption(),
+    )
+    return key_bytes
 
-        Returns:
-            bytes: Private key
-        """
-        return self._private_key
 
-    @property
-    def ca_certificate(self) -> bytes:
-        """Returns the stored CA certificate.
+def generate_certificate(
+    csr: bytes,
+    ca: bytes,
+    ca_key: bytes,
+    validity: int = 365,
+    alt_names: list = None,
+) -> bytes:
+    """Generates a certificate based on CSR.
 
-        Returns:
-            bytes: Stored CA certificate.
-        """
-        return self._ca_certificate
+    Args:
+        csr: CSR Bytes
+        ca: Set the CA certificate, must be PEM format
+        ca_key: The CA key, must be PEM format; if not in CAfile
+        validity: Validity
+        alt_names: Alternative names (optional)
 
-    @property
-    def certificate(self) -> bytes:
-        """Returns the stored certificate.
+    Returns:
+        bytes: Certificate
+    """
+    csr_object = x509.load_pem_x509_csr(csr)
+    subject = csr_object.subject
+    issuer = x509.load_pem_x509_certificate(ca).issuer
+    private_key = serialization.load_pem_private_key(ca_key, password=None)
 
-        Returns:
-            bytes: Certificate
-        """
-        return self._certificate
+    certificate_builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(csr_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=validity))
+    )
 
-    def generate(self, common_name: str) -> None:
-        """Generates and stores certificates.
-
-        Args:
-            common_name (str): Certificate common name
-
-        Returns:
-            None
-        """
-        ca_private_key = self._generate_private_key()
-        private_key = self._generate_private_key()
-        ca_certificate = self._generate_ca(private_key=ca_private_key, subject=common_name)
-        certificate_csr = self._generate_csr(
-            private_key=private_key,
-            subject=common_name,
+    if alt_names:
+        names = [x509.DNSName(n) for n in alt_names]
+        certificate_builder = certificate_builder.add_extension(
+            x509.SubjectAlternativeName(names),
+            critical=False,
         )
-        certificate = self._generate_certificate(
-            csr=certificate_csr,
-            ca=ca_certificate,
-            ca_key=ca_private_key,
+    certificate_builder._version = x509.Version.v1
+    cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def generate_ca(
+    private_key: bytes,
+    subject: str,
+    private_key_password: Optional[bytes] = None,
+    validity: int = 365,
+    country: str = "US",
+) -> bytes:
+    """Generates a CA certificate.
+
+    Args:
+        private_key (bytes): Private key to use
+        subject (str): Certificate subject
+        private_key_password (bytes): Private key password
+        validity (int): Certificate validity (in days)
+        country (str): Country name
+
+    Returns:
+        bytes: Certificate CA (encoded in base64)
+    """
+    private_key_object = serialization.load_pem_private_key(
+        private_key, password=private_key_password
+    )
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
+        ]
+    )
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()  # type: ignore[arg-type]
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key_object.public_key())  # type: ignore[arg-type]
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=validity))
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
         )
-
-        self._private_key = private_key
-        self._ca_certificate = ca_certificate
-        self._certificate = certificate
-
-    @staticmethod
-    def _generate_certificate(
-        csr: bytes,
-        ca: bytes,
-        ca_key: bytes,
-        validity: int = 365,
-        alt_names: list = None,
-    ) -> bytes:
-        """Generates a certificate based on CSR.
-
-        Args:
-            csr: CSR Bytes
-            ca: Set the CA certificate, must be PEM format
-            ca_key: The CA key, must be PEM format; if not in CAfile
-            validity: Validity
-            alt_names: Alternative names (optional)
-
-        Returns:
-            bytes: Certificate
-        """
-        csr_object = x509.load_pem_x509_csr(csr)
-        subject = csr_object.subject
-        issuer = x509.load_pem_x509_certificate(ca).issuer
-        private_key = serialization.load_pem_private_key(ca_key, password=None)
-
-        certificate_builder = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(issuer)
-            .public_key(csr_object.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.utcnow())
-            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=validity))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
         )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
 
-        if alt_names:
-            names = [x509.DNSName(n) for n in alt_names]
-            certificate_builder = certificate_builder.add_extension(
-                x509.SubjectAlternativeName(names),
-                critical=False,
-            )
-        certificate_builder._version = x509.Version.v1
-        cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
-        return cert.public_bytes(serialization.Encoding.PEM)
 
-    @staticmethod
-    def _generate_csr(private_key: bytes, subject: str, country: str = "US") -> bytes:
-        """Generates a CSR.
+def generate_csr(
+    private_key: bytes,
+    subject: str,
+    private_key_password: Optional[bytes] = None,
+    sans: Optional[List[str]] = None,
+    additional_critical_extensions: Optional[List] = None,
+) -> bytes:
+    """Generates a CSR using private key and subject.
 
-        Args:
-            private_key (bytes): Private key to use
-            subject (str): Output the request's subject
-            country (str): Country
+    Args:
+        private_key (bytes): Private key
+        private_key_password (bytes): Private key password
+        subject (str): CSR Subject.
+        sans (list): List of subject alternative names
+        additional_critical_extensions (list): List if critical additional extension objects.
+            Object must be a x509 ExtensionType.
 
-        Returns:
-            bytes: CSR (encoded in base64)
-        """
-        subject = x509.Name(
+    Returns:
+        bytes: CSR
+    """
+    signing_key = serialization.load_pem_private_key(private_key, password=private_key_password)
+    csr = x509.CertificateSigningRequestBuilder(
+        subject_name=x509.Name(
             [
-                x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
                 x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
             ]
         )
-        signing_key = serialization.load_pem_private_key(private_key, password=None)
-        csr = (
-            x509.CertificateSigningRequestBuilder()
-            .subject_name(subject)
-            .sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    if sans:
+        csr = csr.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
         )
-        csr_bytes = csr.public_bytes(serialization.Encoding.PEM)
-        return csr_bytes
-
-    @staticmethod
-    def _generate_ca(
-        private_key: bytes,
-        subject: str,
-        validity: int = 365,
-        country: str = "US",
-    ) -> bytes:
-        """Generates a CA certificate.
-
-        Args:
-            private_key (bytes): Private key to use
-            subject (str): Certificate subject
-            validity (int): Certificate validity (in days)
-            country (str): Country name
-
-        Returns:
-            bytes: Certificate CA (encoded in base64)
-        """
-        private_key_object = serialization.load_pem_private_key(private_key, password=None)
-        subject = issuer = x509.Name(
-            [
-                x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
-                x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
-            ]
-        )
-        subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
-            private_key_object.public_key()  # type: ignore[arg-type]
-        )
-        subject_identifier = key_identifier = subject_identifier_object.public_bytes()
-        cert = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(issuer)
-            .public_key(private_key_object.public_key())  # type: ignore[arg-type]
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.utcnow())
-            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=validity))
-            .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
-            .add_extension(
-                x509.AuthorityKeyIdentifier(
-                    key_identifier=key_identifier,
-                    authority_cert_issuer=None,
-                    authority_cert_serial_number=None,
-                ),
-                critical=False,
-            )
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=None),
-                critical=True,
-            )
-            .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
-        )
-        return cert.public_bytes(serialization.Encoding.PEM)
-
-    @staticmethod
-    def _generate_private_key(key_size: int = 2048, public_exponent: int = 65537) -> bytes:
-        """Generates private key.
-
-        Args:
-            key_size (int): Key size in bytes.
-            public_exponent (int): Public exponent used to generate key.
-
-        Returns:
-            bytes: Private key (encoded in base64)
-        """
-        private_key = rsa.generate_private_key(
-            public_exponent=public_exponent,
-            key_size=key_size,
-        )
-        key_bytes = private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        return key_bytes
+    if additional_critical_extensions:
+        for extension in additional_critical_extensions:
+            csr = csr.add_extension(extension, critical=True)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    return signed_certificate.public_bytes(serialization.Encoding.PEM)
 
 
-class Certificate:
-    """Class for methods associated with a given certificate."""
+def certificate_is_valid(certificate: bytes) -> bool:
+    """Returns whether a certificate is valid.
 
-    def __init__(self, certificate_bytes: bytes):
-        """Sets certificate_bytes based on provided input.
+    Args:
+        certificate:
 
-        Args:
-            certificate_bytes (bytes): Certificate
-        """
-        self.certificate_bytes = certificate_bytes
-
-    @property
-    def is_valid(self) -> bool:
-        """Returns whether certificate is valid.
-
-        Returns:
-            bool: True/False
-        """
-        try:
-            x509.load_pem_x509_certificate(self.certificate_bytes)
-            return True
-        except ValueError:
-            return False
+    Returns:
+        bool: True/False
+    """
+    try:
+        x509.load_pem_x509_certificate(certificate)
+        return True
+    except ValueError:
+        return False
 
 
-class PrivateKey:
-    """Class for methods associated with a given private key."""
+def private_key_is_valid(private_key: bytes) -> bool:
+    """Returns whether a private key is valid.
 
-    def __init__(self, private_key_bytes: bytes):
-        """Sets private_key_bytes based on provided input.
-
-        Args:
-            private_key_bytes (bytes): Private key
-        """
-        self.private_key_bytes = private_key_bytes
-
-    @property
-    def is_valid(self) -> bool:
-        """Returns whether a private key is valid.
-
-        Returns:
-            bool: True/False
-        """
-        try:
-            serialization.load_pem_private_key(self.private_key_bytes, password=None)
-            return True
-        except ValueError:
-            return False
+    Returns:
+        bool: True/False
+    """
+    try:
+        serialization.load_pem_private_key(private_key, password=None)
+        return True
+    except ValueError:
+        return False

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
- Adds preliminary support for v1 of the tls-certificates interface
- Charm supports both v0 and v1 of the interface
- Refactors the creation and use of root certificates
- Adds config option for the root CA common name
- Fixes flake8 version to 4.0.1