### PR TITLE
refactor: remove placeholder image resource

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
 
 jobs:
   lint-report:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,10 +9,6 @@ summary: |
   Charm responsible for distributing certificates through relationship. Certificates are provided
   by the operator through Juju configs.
 
-containers:
-  placeholder:
-    resource: placeholder-image
-
 provides:
   certificates:
     interface: tls-certificates
@@ -20,9 +16,3 @@ provides:
 peers:
   replicas:
     interface: tls-certificates-replica
-
-resources:
-  placeholder-image:
-    type: oci-image
-    description: Placeholder image
-    upstream-source: ubuntu:latest

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,23 +41,13 @@ class TestTLSCertificatesOperator:
     async def test_given_no_config_when_deploy_then_status_is_blocked(  # noqa: E501
         self, ops_test, charm, cleanup
     ):
-        resources = {
-            "placeholder-image": METADATA["resources"]["placeholder-image"]["upstream-source"],
-        }
-        await ops_test.model.deploy(
-            entity_url=charm,
-            resources=resources,
-            application_name=APPLICATION_NAME,
-        )
+        await ops_test.model.deploy(entity_url=charm, application_name=APPLICATION_NAME)
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
 
     async def test_given_correct_config_when_deploy_then_status_is_active(  # noqa: E501
         self, ops_test, charm, cleanup
     ):
-        resources = {
-            "placeholder-image": METADATA["resources"]["placeholder-image"]["upstream-source"],
-        }
         certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
         ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
         certificate_bytes = base64.b64encode(certificate.encode("utf-8"))
@@ -69,7 +59,7 @@ class TestTLSCertificatesOperator:
         }
 
         await ops_test.model.deploy(
-            entity_url=charm, resources=resources, application_name=APPLICATION_NAME, config=config
+            entity_url=charm, application_name=APPLICATION_NAME, config=config
         )
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
@@ -77,9 +67,6 @@ class TestTLSCertificatesOperator:
     async def test_given_correct_config_when_deploy_and_scale_then_status_is_active(  # noqa: E501
         self, ops_test, charm, cleanup
     ):
-        resources = {
-            "placeholder-image": METADATA["resources"]["placeholder-image"]["upstream-source"],
-        }
         certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
         ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
         certificate_bytes = base64.b64encode(certificate.encode("utf-8"))
@@ -92,7 +79,6 @@ class TestTLSCertificatesOperator:
 
         await ops_test.model.deploy(
             entity_url=charm,
-            resources=resources,
             application_name=APPLICATION_NAME,
             config=config,
         )


### PR DESCRIPTION
# Description

Removes the placeholder image. This is not actually needed, and without it this charm will likely work on both machines and Kubernetes :rocket: This will need to be verified and probably backed up by a test, but this PR removes the image either way, as it's not used for anything and not required for deployment on Kubernetes.

EDIT: Bonus updating the CI to run all the tests on a PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
