### PR TITLE
Added extensions support in the certificate generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+.idea/
+.tox/
+.mypy_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 jsonschema
 cryptography

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,6 +41,7 @@ class TestTLSCertificatesOperator:
         await ops_test.model.deploy(
             entity_url=charm,
             application_name=APPLICATION_NAME,
+            series="focal",
         )
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
@@ -64,6 +65,7 @@ class TestTLSCertificatesOperator:
             entity_url=charm,
             application_name=APPLICATION_NAME,
             config=config,
+            series="focal",
         )
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
@@ -87,6 +89,7 @@ class TestTLSCertificatesOperator:
             entity_url=charm,
             application_name=APPLICATION_NAME,
             config=config,
+            series="focal",
         )
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,7 +5,7 @@ import base64
 import logging
 
 import pytest
-from juju.errors import JujuError  # type: ignore[import]
+from juju.errors import JujuError
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,10 +5,18 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 
+from charms.tls_certificates_interface.v1.tls_certificates import generate_csr # type: ignore
+from cryptography import x509
+from cryptography.x509 import DNSName
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from charm import TLSCertificatesOperatorCharm
+from self_signed_certificates import (
+    generate_ca,
+    generate_certificate,
+    generate_private_key,
+)
 
 testing.SIMULATE_CAN_CONNECT = True
 
@@ -384,3 +392,24 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Root Certificates are not yet set"),
             self.harness.charm.unit.status,
         )
+
+    def test_given_self_signed_certificates_with_additional_extensions(self):
+        """Test setting an extension on a CSR and retrieving it from the cert."""
+        peer_relation_id = self.harness.add_relation("replicas", self.harness.charm.app.name)
+        self.harness.add_relation_unit(peer_relation_id, self.harness.charm.unit.name)
+
+        csr = generate_csr(
+            generate_private_key(),
+            subject="my_subject",
+            sans=["www.canonical.com"],
+        )
+
+        ca_private_key = generate_private_key()
+        ca_certificate = generate_ca(ca_private_key, "ca")
+        certificate = generate_certificate(csr, ca_certificate, ca_private_key)
+
+        cert = x509.load_pem_x509_certificate(certificate)
+        san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        subj_alt_names = san_ext.value.get_values_for_type(DNSName)
+
+        self.assertCountEqual(subj_alt_names, ["www.canonical.com"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,9 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 
-from charms.tls_certificates_interface.v1.tls_certificates import generate_csr # type: ignore
+from charms.tls_certificates_interface.v1.tls_certificates import (  # type: ignore
+    generate_csr,
+)
 from cryptography import x509
 from cryptography.x509 import DNSName
 from ops import testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -395,7 +395,7 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
         )
 
-    def test_given_sans_added_to_csr_when_created_then_set_the_correct_extension_on_generated_certificate(  # noqa: E501
+    def test_given_sans_added_to_csr_when_generate_certificate_then_the_correct_extensions_are_set_in_generated_certificate(  # noqa: E501
         self,
     ):
         peer_relation_id = self.harness.add_relation("replicas", self.harness.charm.app.name)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -395,15 +395,17 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
         )
 
-    def test_given_self_signed_certificates_with_additional_extensions(self):
-        """Test setting an extension on a CSR and retrieving it from the cert."""
+    def test_given_sans_added_to_csr_when_created_then_set_the_correct_extension_on_generated_certificate(  # noqa: E501
+        self,
+    ):
         peer_relation_id = self.harness.add_relation("replicas", self.harness.charm.app.name)
         self.harness.add_relation_unit(peer_relation_id, self.harness.charm.unit.name)
 
+        sans = ["www.canonical.com", "test.com"]
         csr = generate_csr(
             generate_private_key(),
             subject="my_subject",
-            sans=["www.canonical.com"],
+            sans=sans,
         )
 
         ca_private_key = generate_private_key()
@@ -414,4 +416,4 @@ class TestCharm(unittest.TestCase):
         san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
         subj_alt_names = san_ext.value.get_values_for_type(DNSName)
 
-        self.assertCountEqual(subj_alt_names, ["www.canonical.com"])
+        self.assertCountEqual(subj_alt_names, sans)


### PR DESCRIPTION
# Description

- This PR addresses the issue reported [here](https://github.com/canonical/tls-certificates-operator/issues/14).
- This PR passes the extensions set on the CSR to the certificate. 
- The certificate builder version has been set to `x509.Version.v3` to add support for extensions such as the `SubjectAlternativeName`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
