### PR TITLE
Revoke all issued certificates on config_changed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -260,6 +260,8 @@ class TLSCertificatesOperatorCharm(CharmBase):
         self._store_self_signed_ca_private_key(private_key.decode())
         self._store_self_signed_ca_private_key_password(private_key_password)
         logger.info("Root certificates generated and stored.")
+        self.tls_certificates.revoke_all_certificates()
+        logger.info("Revoked all previously issued certificates.")
 
     def _relation_created(self, relation_name: str) -> bool:
         """Returns whether given relation was created.
@@ -343,6 +345,8 @@ class TLSCertificatesOperatorCharm(CharmBase):
                 base64.b64decode(certificate_config).decode("utf-8").strip(),
             ]
         self._store_config_ca_chain(ca_chain_list)
+        self.tls_certificates.revoke_all_certificates()
+        logger.info("Revoked all previously issued certificates.")
 
     def _generate_self_signed_certificates(self, certificate_signing_request: str) -> str:
         """Generates self-signed certificates.

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

Revoke all issued certificates on config_changed. Whenever the configuration has been changed, this operator will provide new certificates. To trigger Requirer charm to request new certificates, all issued certificates will be revoked (removed from the relation data bag). Since we are not using a CRL or OCSP, the previously issued certificates will still be valid until their expiry date.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
