### PR TITLE
Add action to generate certificates

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+generate-certificate:
+  description: Generate a certificate along with private key.
+  params:
+    cn:
+      type: string
+      description: >-
+        CN (Common Name) field of the new certificate
+    sans:
+      type: string
+      description: >-
+        Space delimited list of Subject Alternate Name/IP addresse(s).
+      default: ''
+  required:
+    - cn
+  additionalProperties: False

--- a/actions.yaml
+++ b/actions.yaml
@@ -4,7 +4,7 @@
 generate-certificate:
   description: Generate a certificate along with private key.
   params:
-    cn:
+    common-name:
       type: string
       description: >-
         CN (Common Name) field of the new certificate
@@ -14,5 +14,5 @@ generate-certificate:
         Space delimited list of Subject Alternate Name/IP addresse(s).
       default: ''
   required:
-    - cn
+    - common-name
   additionalProperties: False

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,8 +1,11 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-generate-certificate:
-  description: Generate a certificate along with private key.
+generate-self-signed-certificate:
+  description: >-
+    Generate a certificate along with private key.
+    Supported only when the tls-certificate-operator
+    is configured to be self-signed.
   params:
     common-name:
       type: string


### PR DESCRIPTION
Feature request to add an action to generate
certificates along with private key. Currently
the charms can relate to tls-certificates-operator charm and request for certificates via the integration. An action is required to request for certificate by a non-charmed application.
Microstack (aka sunbeam) [1] is one such example which requests certificate via actions.

[1] https://github.com/openstack-snaps/snap-microstack

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
