### PR TITLE
Fix charm build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-to-charmhub:
     name: Release to Charmhub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,8 +6,6 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "20.04"
-    - name: "ubuntu"
-      channel: "22.04"
     run-on:
     - name: "ubuntu"
       channel: "20.04"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -506,7 +506,7 @@ class TestCharm(unittest.TestCase):
         cert = x509.load_pem_x509_certificate(certificate)
         san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
         subj_alt_names = san_ext.value.get_values_for_type(DNSName)
-        self.assertEqual(subj_alt_names, sans.split(" "))
+        self.assertCountEqual(subj_alt_names, sans.split(" "))
 
     def test_given_self_signed_option_is_true_and_unit_is_leader_and_self_signed_certs_are_not_yet_stored_when_generate_certificate_action_triggered_then_action_failed(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

The currently published charm on charmhub's edge channel is broken. It is a weird beast built on 22.04 but trying to run on 20.04.

The `publish` action uses `destructive` mode, and it will by default use a base matching the underlying system. Since we are using `ubuntu-latest` in the workflow and we have a base defined for 22.04, when `ubuntu-latest` started pointing to 22.04, the build broke.

This PR changes the workflow to pin the version to 20.04 and also removes the base for 22.04.

It also includes a small fix for a flaky test introduced in the last PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
