### PR TITLE
Install charmcraft before using it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install charmcraft
+        run: snap install charmcraft --classic
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Description

Last PR introduced changes to the workflow for publishing the charm by using charmcraft directly. It however was missing a step to install charmcraft.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
