### PR TITLE
chore: drop noisy update_status warnings to debug

### DIFF
--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -271,7 +271,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1326,10 +1326,10 @@ class TLSCertificatesRequiresV1(Object):
         """
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            logger.warning(f"No relation: {self.relationship_name}")
+            logger.debug(f"No relation: {self.relationship_name}")
             return
         if not relation.app:
-            logger.warning(f"No remote app in relation: {self.relationship_name}")
+            logger.debug(f"No remote app in relation: {self.relationship_name}")
             return
         provider_relation_data = _load_relation_data(relation.data[relation.app])
         if not self._relation_data_is_valid(provider_relation_data):


### PR DESCRIPTION
# Description

Existing logs spit out warnings on every `update_status` event for as long as the charm references `TLSCertificatesRequiresV1`. This is very annoying. Have dropped warning to `DEBUG`.
Example:

```
unit-kafka-0: 17:30:14 WARNING unit.kafka/0.juju-log No relation: certificates
unit-zookeeper-1: 17:31:24 WARNING unit.zookeeper/1.juju-log No relation: certificates
unit-zookeeper-2: 17:32:15 WARNING unit.zookeeper/2.juju-log No relation: certificates
unit-zookeeper-0: 17:32:17 WARNING unit.zookeeper/0.juju-log No relation: certificates
unit-kafka-0: 17:34:46 WARNING unit.kafka/0.juju-log No relation: certificates
unit-zookeeper-1: 17:36:25 WARNING unit.zookeeper/1.juju-log No relation: certificates
unit-zookeeper-2: 17:37:29 WARNING unit.zookeeper/2.juju-log No relation: certificates
unit-zookeeper-0: 17:37:31 WARNING unit.zookeeper/0.juju-log No relation: certificates
unit-kafka-0: 17:40:42 WARNING unit.kafka/0.juju-log No relation: certificates
unit-zookeeper-1: 17:41:32 WARNING unit.zookeeper/1.juju-log No relation: certificates
unit-zookeeper-2: 17:41:54 WARNING unit.zookeeper/2.juju-log No relation: certificates
unit-zookeeper-0: 17:41:56 WARNING unit.zookeeper/0.juju-log No relation: certificates
```

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
