### PR TITLE
Deprecates the use of self-signed certificates feature

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/telco

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ juju relate tls-certificates-operator your-charm
 
 ### With self-signed certificates (deprecated)
 
-> **Warning**: This feature is deprecated, please use the 
+> **Warning**: This feature is deprecated and will be dropped in the future, please use the 
 > [self-signed-certificates](https://charmhub.io/self-signed-certificates) operator.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ juju deploy tls-certificates-operator \
 juju relate tls-certificates-operator your-charm
 ```
 
-### With self-signed certificates
+### With self-signed certificates (deprecated)
 
-> **Warning**: This configuration option is unsecure and should be used for testing only.
+> **Warning**: This feature is deprecated, please use the 
+> [self-signed-certificates](https://charmhub.io/self-signed-certificates) operator.
 
 ```bash
 juju deploy tls-certificates-operator \

--- a/config.yaml
+++ b/config.yaml
@@ -5,15 +5,24 @@ options:
   generate-self-signed-certificates:
     type: boolean
     default: false
-    description: Generate self-signed certificates and ignores provided certificates.
+    description: |
+      This feature is deprecated, please use the self-signed-certificates operator.
+      
+      Generate self-signed certificates and ignores provided certificates.
   ca-common-name:
     type: string
     default:
-    description: Common name to be used only if `generate-self-signed-certificates` set to true.
+    description: |
+      This feature is deprecated, please use the self-signed-certificates operator.
+      
+      Common name to be used only if `generate-self-signed-certificates` set to true.
   certificate-validity:
     type: int
     default: 365
-    description: Certificate validity (in days) only if `generate-self-signed-certificates` set to true.
+    description: |
+      This feature is deprecated, please use the self-signed-certificates operator.
+      
+      Certificate validity (in days) only if `generate-self-signed-certificates` set to true.
   certificate:
     type: string
     default:

--- a/src/charm.py
+++ b/src/charm.py
@@ -296,6 +296,10 @@ class TLSCertificatesOperatorCharm(CharmBase):
             event.defer()
             return
         if self._self_signed_certificates:
+            logger.warning(
+                "The `self-signed` feature is deprecated, "
+                "please use the self-signed-certificates operator."
+            )
             if self.unit.is_leader():
                 if not self._config_ca_common_name:
                     self.unit.status = BlockedStatus(

--- a/src/charm.py
+++ b/src/charm.py
@@ -297,7 +297,7 @@ class TLSCertificatesOperatorCharm(CharmBase):
             return
         if self._self_signed_certificates:
             logger.warning(
-                "The `self-signed` feature is deprecated, "
+                "The `self-signed` feature is deprecated and will be dropped in the furure, "
                 "please use the self-signed-certificates operator."
             )
             if self.unit.is_leader():


### PR DESCRIPTION
# Description

Deprecates the use of self-signed certificates feature. People requiring self-signed certificates in the Juju world should now use the [self-signed-certificates operator](https://charmhub.io/self-signed-certificates).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
