### PR TITLE
Add ca-certificate-validity config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ List of configuration options:
 - **certificate (string)**: Base64 encoded TLS certificate (do not use if 'generate-self-signed-certificates' is set to true).
 - **ca-certificate (string)**: Base64 encoded CA Certificate (do not use if 'generate-self-signed-certificates' is set to true).
 - **ca-chain (string)**: Base64 encoded CA Chain (do not use if 'generate-self-signed-certificates' is set to true).
+- **ca-certificate-validity(int)**: Integer representing the number of days for which the self-signed certificates are valid (only use if 'generate-self-signed-certificates' is set to true). Its value should not be smaller than `certificate-validity`.
+- **certificate-validity(int)**: Integer representing the number of days for which the self-signed certificates are valid (only use if 'generate-self-signed-certificates' is set to true). Its value should not be larger than `ca-certificate-validity`.
 
 
 ## Relations

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,13 @@ options:
       This feature is deprecated, please use the self-signed-certificates operator.
       
       Common name to be used only if `generate-self-signed-certificates` set to true.
+  ca-certificate-validity:
+    type: int
+    default: 365
+    description: |
+      This feature is deprecated, please use the self-signed-certificates operator.
+
+      CA Certificate validity (in days) only if `generate-self-signed-certificates` set to true.
   certificate-validity:
     type: int
     default: 365

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,10 +59,7 @@ class TLSCertificatesOperatorCharm(CharmBase):
         Returns:
             int: Certificate validity (in days)
         """
-        certificate_validity = int(self.model.config.get("certificate-validity", 365))
-        if certificate_validity > self._ca_certificate_validity:
-            logger.warning("certificate validity is larger than CA certificate validity")
-        return certificate_validity
+        return int(self.model.config.get("certificate-validity", 365))
 
     @property
     def _ca_certificate_validity(self) -> int:
@@ -320,6 +317,13 @@ class TLSCertificatesOperatorCharm(CharmBase):
                         "`generate-self-signed-certificates` is set to True."
                     )
                     return
+
+                if self._certificate_validity > self._ca_certificate_validity:
+                    self.unit.status = BlockedStatus(
+                        "certificate validity is larger than CA certificate validity"
+                    )
+                    return
+
                 self._generate_root_certificates()
                 self.tls_certificates.revoke_all_certificates()
                 logger.info("Revoked all previously issued certificates.")

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,8 +62,7 @@ class TLSCertificatesOperatorCharm(CharmBase):
         certificate_validity = int(self.model.config.get("certificate-validity", 365))
         if certificate_validity > self._ca_certificate_validity:
             logger.warning(
-                f"certificate validity is larger than CA certificate validity: "
-                f"{certificate_validity} > {self._ca_certificate_validity}"
+                f"certificate validity is larger than CA certificate validity"
             )
         return certificate_validity
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,9 +61,7 @@ class TLSCertificatesOperatorCharm(CharmBase):
         """
         certificate_validity = int(self.model.config.get("certificate-validity", 365))
         if certificate_validity > self._ca_certificate_validity:
-            logger.warning(
-                f"certificate validity is larger than CA certificate validity"
-            )
+            logger.warning("certificate validity is larger than CA certificate validity")
         return certificate_validity
 
     @property

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,7 @@ from charms.tls_certificates_interface.v1.tls_certificates import (  # type: ign
 from cryptography import x509
 from cryptography.x509 import DNSName
 from ops import testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus, Relation, Application
+from ops.model import ActiveStatus, Application, BlockedStatus, Relation, WaitingStatus
 
 from charm import TLSCertificatesOperatorCharm
 from self_signed_certificates import (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 import base64
 import datetime
 import json
-import logging
 import unittest
 from unittest.mock import Mock, patch
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,7 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 import base64
+import datetime
 import json
+import logging
 import unittest
 from unittest.mock import Mock, patch
 
@@ -168,6 +170,73 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
         )
 
+    def test_given_unit_is_leader_and_generate_self_signed_certificate_set_to_true_default_validity(  # noqa: E501
+        self,
+    ):
+        self.harness.set_leader(True)
+        self.harness.add_relation("replicas", self.harness.charm.app.name)
+
+        self.harness.update_config(
+            key_values={"generate-self-signed-certificates": "true", "ca-common-name": "RootCA"}
+        )
+
+        rel = self.harness.charm.model.get_relation("replicas")
+        cert = x509.load_pem_x509_certificate(
+            rel.data[rel.app]["self_signed_ca_certificate"].encode("utf-8")
+        )
+        assert (
+            cert.not_valid_after.date()
+            == (datetime.datetime.now() + datetime.timedelta(days=365)).date()
+        )
+
+    def test_given_unit_is_leader_and_generate_self_signed_certificate_set_to_true_custom_validity(  # noqa: E501
+        self,
+    ):
+        self.harness.set_leader(True)
+        self.harness.add_relation("replicas", self.harness.charm.app.name)
+
+        n = 500
+
+        self.harness.update_config(
+            key_values={
+                "generate-self-signed-certificates": "true",
+                "ca-common-name": "RootCA",
+                "ca-certificate-validity": n,
+            }
+        )
+
+        rel = self.harness.charm.model.get_relation("replicas")
+        cert = x509.load_pem_x509_certificate(
+            rel.data[rel.app]["self_signed_ca_certificate"].encode("utf-8")
+        )
+        assert (
+            cert.not_valid_after.date()
+            == (datetime.datetime.now() + datetime.timedelta(days=n)).date()
+        )
+
+    def test_given_not_consistent_ca_certificate_and_certificate_validity(  # noqa: E501
+        self,
+    ):
+        self.harness.set_leader(True)
+        self.harness.add_relation("replicas", self.harness.charm.app.name)
+
+        self.harness.update_config(
+            key_values={
+                "generate-self-signed-certificates": "true",
+                "ca-common-name": "RootCA",
+                "ca-certificate-validity": 100,
+            }
+        )
+
+        with self.assertLogs(level=logging.WARNING) as logs:
+            _ = self.harness.charm._certificate_validity
+
+        self.assertEqual(len(logs.records), 1)
+        self.assertTrue(
+            "certificate validity is larger than CA certificate validity"
+            in logs.records[0].message
+        )
+
     def test_given_missing_configuration_options_when_config_changed_then_status_is_blocked(self):
         self.harness.add_relation("replicas", self.harness.charm.app.name)
         key_values = {"ca-chain": "Whatever ca chain"}
@@ -327,7 +396,8 @@ class TestCharm(unittest.TestCase):
         "charms.tls_certificates_interface.v1.tls_certificates.TLSCertificatesProvidesV1.set_relation_certificate"  # noqa: E501, W505
     )
     def test_given_configuration_options_are_set_and_unit_is_not_leader_when_certificate_creation_request_then_certificates_are_not_passed(  # noqa: E501
-        self, patch_set_relation_certificates
+        self,
+        patch_set_relation_certificates,
     ):
         event = Mock()
         event.relation_id = 1234

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,7 @@ from charms.tls_certificates_interface.v1.tls_certificates import (  # type: ign
 from cryptography import x509
 from cryptography.x509 import DNSName
 from ops import testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus, Relation, Application
 
 from charm import TLSCertificatesOperatorCharm
 from self_signed_certificates import (
@@ -181,6 +181,10 @@ class TestCharm(unittest.TestCase):
         )
 
         rel = self.harness.charm.model.get_relation("replicas")
+
+        assert isinstance(rel, Relation)
+        assert isinstance(rel.app, Application)
+
         cert = x509.load_pem_x509_certificate(
             rel.data[rel.app]["self_signed_ca_certificate"].encode("utf-8")
         )
@@ -201,11 +205,15 @@ class TestCharm(unittest.TestCase):
             key_values={
                 "generate-self-signed-certificates": "true",
                 "ca-common-name": "RootCA",
-                "ca-certificate-validity": n,
+                "ca-certificate-validity": str(n),
             }
         )
 
         rel = self.harness.charm.model.get_relation("replicas")
+
+        assert isinstance(rel, Relation)
+        assert isinstance(rel.app, Application)
+
         cert = x509.load_pem_x509_certificate(
             rel.data[rel.app]["self_signed_ca_certificate"].encode("utf-8")
         )
@@ -224,7 +232,7 @@ class TestCharm(unittest.TestCase):
             key_values={
                 "generate-self-signed-certificates": "true",
                 "ca-common-name": "RootCA",
-                "ca-certificate-validity": 100,
+                "ca-certificate-validity": "100",
             }
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -236,14 +236,7 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        with self.assertLogs(level=logging.WARNING) as logs:
-            _ = self.harness.charm._certificate_validity
-
-        self.assertEqual(len(logs.records), 1)
-        self.assertTrue(
-            "certificate validity is larger than CA certificate validity"
-            in logs.records[0].message
-        )
+        self.assertTrue(type(self.harness.charm.unit.status), BlockedStatus)
 
     def test_given_missing_configuration_options_when_config_changed_then_status_is_blocked(self):
         self.harness.add_relation("replicas", self.harness.charm.app.name)


### PR DESCRIPTION
# Description

Given the TLS certificate operator already provides the possibility of configuring the period of validity of the certificates, it makes sense to allow to specify the validity for CA certificate as well, when generating the CA/certs. If these modifications sounds sensible, I would be more than happy to introduce them in the new charm https://github.com/canonical/self-signed-certificates-operator. Although this behaviour in this charm is now deprecated, we still need this feature for a use-case which is still on juju 2.9.42+.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
