### PR TITLE
Adds requirer charm to the integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
+          juju-channel: 3.1/stable
           provider: microk8s
+          channel: 1.27-strict/stable
       - name: Run integration tests
         run: tox -e integration
       - name: Archive Tested Charm

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -10,6 +10,7 @@ from juju.errors import JujuError
 logger = logging.getLogger(__name__)
 
 APPLICATION_NAME = "tls-certificates-operator"
+TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
 
 
 class TestTLSCertificatesOperator:
@@ -106,3 +107,47 @@ class TestTLSCertificatesOperator:
         await ops_test.model.applications[APPLICATION_NAME].scale(1)
 
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+    async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
+        self, ops_test, charm, cleanup
+    ):
+        await ops_test.model.deploy(
+            TLS_REQUIRER_CHARM_NAME,
+            application_name=TLS_REQUIRER_CHARM_NAME,
+            channel="edge",
+        )
+        await ops_test.model.add_relation(
+            relation1=f"{APPLICATION_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[TLS_REQUIRER_CHARM_NAME],
+            status="active",
+            timeout=1000,
+        )
+        action_output = await run_get_certificate_action(ops_test)
+        assert action_output["certificate"] == self.get_certificate_from_file(
+            filename="tests/certificate.pem"
+        )
+        assert action_output["ca-certificate"] == self.get_certificate_from_file(
+            filename="tests/ca_certificate.pem"
+        )
+        assert action_output["chain"] == self.get_certificate_from_file(
+            filename="tests/ca_chain.pem"
+        )
+
+
+async def run_get_certificate_action(ops_test) -> dict:
+    """Runs `get-certificate` on the `tls-requirer-requirer/0` unit.
+
+    Args:
+        ops_test (OpsTest): OpsTest
+
+    Returns:
+        dict: Action output
+    """
+    tls_requirer_unit = ops_test.model.units[f"{TLS_REQUIRER_CHARM_NAME}/0"]
+    action = await tls_requirer_unit.run_action(
+        action_name="get-certificate",
+    )
+    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
+    return action_output

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -151,10 +151,17 @@ class TestTLSCertificatesOperator:
         assert action_output["ca-certificate"] == self.get_certificate_from_file(
             filename="tests/ca_certificate.pem"
         ).strip("\n")
-        joined_chain = "\n".join(action_output["chain"])
-        assert joined_chain == self.get_certificate_from_file(filename="tests/ca_chain.pem").strip(
-            "\n"
+        formatted_chain = (
+            action_output["chain"]
+            .replace("[", "")
+            .replace("]", "")
+            .replace("'", "")
+            .replace(", ", "\n")
+            .replace("\\n", "\n")
         )
+        assert formatted_chain == self.get_certificate_from_file(
+            filename="tests/ca_chain.pem"
+        ).strip("\n")
 
 
 async def run_get_certificate_action(ops_test) -> dict:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -145,18 +145,15 @@ class TestTLSCertificatesOperator:
             timeout=1000,
         )
         action_output = await run_get_certificate_action(ops_test)
-        assert (
-            action_output["certificate"]
-            == self.get_certificate_from_file(filename="tests/certificate.pem").strip('\n')
-        )
-        assert (
-            action_output["ca-certificate"]
-            == self.get_certificate_from_file(filename="tests/ca_certificate.pem").strip('\n')
-        )
-        joined_chain = '\n'.join(action_output["chain"])
-        assert (
-            joined_chain
-            == self.get_certificate_from_file(filename="tests/ca_chain.pem").strip('\n')
+        assert action_output["certificate"] == self.get_certificate_from_file(
+            filename="tests/certificate.pem"
+        ).strip("\n")
+        assert action_output["ca-certificate"] == self.get_certificate_from_file(
+            filename="tests/ca_certificate.pem"
+        ).strip("\n")
+        joined_chain = "\n".join(action_output["chain"])
+        assert joined_chain == self.get_certificate_from_file(filename="tests/ca_chain.pem").strip(
+            "\n"
         )
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -145,12 +145,8 @@ class TestTLSCertificatesOperator:
             timeout=1000,
         )
         action_output = await run_get_certificate_action(ops_test)
-        assert action_output["certificate"] == self.get_certificate_from_file(
-            filename="tests/certificate.pem"
-        ).strip("\n")
-        assert action_output["ca-certificate"] == self.get_certificate_from_file(
-            filename="tests/ca_certificate.pem"
-        ).strip("\n")
+        assert action_output["certificate"] == certificate.strip("\n")
+        assert action_output["ca-certificate"] == ca_certificate.strip("\n")
         formatted_chain = (
             action_output["chain"]
             .replace("[", "")
@@ -159,9 +155,7 @@ class TestTLSCertificatesOperator:
             .replace(", ", "\n")
             .replace("\\n", "\n")
         )
-        assert formatted_chain == self.get_certificate_from_file(
-            filename="tests/ca_chain.pem"
-        ).strip("\n")
+        assert formatted_chain == ca_chain.strip("\n")
 
 
 async def run_get_certificate_action(ops_test) -> dict:

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju<3.1
+    juju>=3.1
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

Adds requirer charm to the integration tests:
- Checks if certificate is provided using the get-certificate action of the tls-requirer-operator charm


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
