### PR TITLE
Merges actions get-outstanding-certificate-requests and get-certificate-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This charm is used to provide X.509 certificates in environments where certifica
 ### Providing X.509 certificates to requesting units
 
 The following Juju actions make it possible for the user to manually provide certificates to units of the requirer charm.
-If the oprional parameter relation-id is provided then only the information of the specified relation is returned.
+If the optional parameter relation-id is provided then only the information of the specified relation is returned.
 
 The following action will return all certificate requests that don't have certificates already provided, along with further information (relation_id, application_name and unit_name)
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,18 @@ This charm is used to provide X.509 certificates in environments where certifica
 
 ### Providing X.509 certificates to requesting units
 
-The following three Juju actions make it possible for the user to manually provide certificates to units of the requirer charm.
+The following Juju actions make it possible for the user to manually provide certificates to units of the requirer charm.
+If the oprional parameter relation-id is provided then only the information of the specified relation is returned.
 
 The following action will return all certificate requests that don't have certificates already provided, along with further information (relation_id, application_name and unit_name)
 
 ```bash
-juju run tls-certificates-operator/leader get-outstanding-certificate-requests
-```
-
-The second action is used to get the certificate requests and their information from a specific relation by providing the relation_id as a parameter:
-
-```bash
-juju run tls-certificates-operator/leader get-certificate-request \
+juju run tls-certificates-operator/leader get-outstanding-certificate-requests \
   relation_id=<id>
 ```
 
-The third action allows the user to provide the certificates and specify the csr.
+
+The second action allows the user to provide the certificates and specify the csr.
 ```bash
 juju run tls-certificates-operator/leader provide-certificate \
   relation_id=<id> \

--- a/actions.yaml
+++ b/actions.yaml
@@ -4,17 +4,12 @@
 get-outstanding-certificate-requests:
   description: >-
     Get list of all outstanding certificate signing requests.
-
-get-certificate-request:
-  description: >-
-    Get certificate signing requests from a specific requirer application.
+    If a relation_id is provided, only requests for that relation are returned.
   params:
     relation_id:
       type: string
       description: >-
         ID of the relation between the tls-certificate-operator and the requirer.
-  required:
-    - relation_id
 
 provide-certificate:
   description: >-

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,10 +53,6 @@ class TLSCertificatesOperatorCharm(CharmBase):
             self._on_get_outstanding_certificate_requests_action,
         )
         self.framework.observe(
-            self.on.get_certificate_request_action,
-            self._on_get_certificate_request_action,
-        )
-        self.framework.observe(
             self.on.provide_certificate_action,
             self._on_provide_certificate_action,
         )
@@ -87,25 +83,10 @@ class TLSCertificatesOperatorCharm(CharmBase):
             event.fail(message="No certificates relation has been created yet.")
             return None
 
-        event.set_results({"result": self.tls_certificates.get_requirer_csrs_with_no_certs()})
-
-    def _on_get_certificate_request_action(self, event: ActionEvent) -> None:
-        """Returns certificate request for a specific relation.
-
-        Args:
-            event: Juju event.
-
-        Returns:
-            None
-        """
-        if not self._relation_created("certificates"):
-            event.fail(message="No certificates relation has been created yet.")
-            return None
-
         event.set_results(
             {
-                "result": self.tls_certificates.get_requirer_csrs(
-                    relation_id=event.params["relation_id"]
+                "result": self.tls_certificates.get_requirer_csrs_with_no_certs(
+                    relation_id=event.params.get("relation_id")
                 )
             }
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -137,13 +137,13 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
         event.set_results.assert_called_once_with({"result": example_unit_csrs})
 
-    def test_given_relation_id_not_exist_when_get_certificate_request_action_then_action_returns_empty_list(  # noqa: E501
+    def test_given_relation_id_not_exist_when_get_outstanding_certificate_requests_action_then_action_returns_empty_list(  # noqa: E501
         self,
     ):
         event = Mock()
         self.harness.add_relation("certificates", "requirer")
         event.params = {"relation_id": 1235}
-        self.harness.charm._on_get_certificate_request_action(event=event)
+        self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
         event.set_results.assert_called_once_with({"result": []})
 
     @patch(


### PR DESCRIPTION
# Description

Merges actions get-outstanding-certificate-requests and get-certificate-request into one action that has an optional `relation-id` param.
Depends on https://github.com/canonical/tls-certificates-interface/pull/67 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
