### PR TITLE
Use label for bug reports instead of putting text in the title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
-labels: ''
+title: ""
+labels: ["bug"]
 assignees: ''
 
 ---


### PR DESCRIPTION
# Description

This change makes proper use of github labels for the bug report, instead of tagging the title with "[BUG]"

We could also make use of [GitHub issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) -- but they currently don't support a way to let users upload files. This feature is still in beta, so maybe it is best to just use this markdown template for now.

Live test on my fork: https://github.com/DanielArndt/tls-certificates-operator/issues/new/choose

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
