### PR TITLE
Add CSR validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ juju run tls-certificates-operator/leader provide-certificate \
   certificate="$(base64 -w0 certificate.pem)" \
   ca-chain="$(base64 -w0 ca-chain.pem)" \
   ca-certificate="$(base64 -w0 ca-certificate.pem)" \
-  certificate-signing-request="$(base64 -w0 csr.pem)\
+  certificate-signing-request="$(base64 -w0 csr.pem)" \
 ```
 
 ## Integrations

--- a/src/charm.py
+++ b/src/charm.py
@@ -14,6 +14,7 @@ from typing import Dict, List
 
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     TLSCertificatesProvidesV2,
+    csr_matches_certificate,
 )
 from ops.charm import ActionEvent, CharmBase, EventBase, InstallEvent
 from ops.main import main
@@ -118,6 +119,14 @@ class TLSCertificatesOperatorCharm(CharmBase):
         certificate = base64.b64decode(event.params["certificate"]).decode("utf-8").strip()
         ca_cert = base64.b64decode(event.params["ca-certificate"]).decode("utf-8").strip()
 
+        if not self._csr_exists_in_requirer(csr=csr, relation_id=event.params["relation-id"]):
+            event.fail(message="Certificate signing request was not found in requirer data.")
+            return
+
+        if not csr_matches_certificate(csr=csr, cert=certificate):
+            event.fail(message="Certificate and CSR do not match.")
+            return
+
         try:
             self.tls_certificates.set_relation_certificate(
                 certificate_signing_request=csr,
@@ -131,6 +140,14 @@ class TLSCertificatesOperatorCharm(CharmBase):
             return
         event.set_results({"result": "Certificates successfully provided."})
         self._set_active_status(event=event)
+
+    def _csr_exists_in_requirer(self, csr: str, relation_id: str) -> bool:
+        all_unit_csr_mappings = self.tls_certificates.get_requirer_csrs(relation_id)
+        for csr_mappings in all_unit_csr_mappings:
+            for csrs in csr_mappings["unit_csrs"]:
+                if csr in csrs["certificate_signing_request"]:
+                    return True
+        return False
 
     def _action_certificates_are_valid(
         self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -141,11 +141,20 @@ class TLSCertificatesOperatorCharm(CharmBase):
         event.set_results({"result": "Certificates successfully provided."})
         self._set_active_status(event=event)
 
-    def _csr_exists_in_requirer(self, csr: str, relation_id: str) -> bool:
+    def _csr_exists_in_requirer(self, csr: str, relation_id: int) -> bool:
+        """Validates certificates provided in action.
+
+        Args:
+            csr (str): certificate signing request in their original str representation.
+            relation_id (int): Relation id with the requirer.
+
+        Returns:
+            bool: Whether the csr exists on the requirer.
+        """
         all_unit_csr_mappings = self.tls_certificates.get_requirer_csrs(relation_id)
         for csr_mappings in all_unit_csr_mappings:
             for csrs in csr_mappings["unit_csrs"]:
-                if csr in csrs["certificate_signing_request"]:
+                if csr == csrs["certificate_signing_request"]:
                     return True
         return False
 
@@ -166,7 +175,7 @@ class TLSCertificatesOperatorCharm(CharmBase):
             ca_chain (str): CA Chain in base64 string format
 
         Returns:
-            bool: Wether certificates are valid.
+            bool: Whether certificates are valid.
         """
         try:
             certificate_bytes = self._decode_base64(certificate, "certificate")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -160,9 +160,6 @@ class TestTLSCertificatesOperator:
             timeout=1000,
         )
 
-        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
-        ca_chain_bytes = base64.b64encode(ca_chain.encode("utf-8"))
-
         action_output = await run_get_outstanding_csrs_action(ops_test)
 
         action_result_list = ast.literal_eval(action_output["result"])
@@ -174,6 +171,8 @@ class TestTLSCertificatesOperator:
         ca_certificate_pem = certs["ca_cert"].public_bytes(serialization.Encoding.PEM)
         certificate_bytes = base64.b64encode(certificate_pem)
         ca_certificate_bytes = base64.b64encode(ca_certificate_pem)
+        ca_chain_pem = ca_certificate_pem + certificate_pem
+        ca_chain_bytes = base64.b64encode(ca_chain_pem)
 
         action_output = await run_provide_certificate_action(
             ops_test,
@@ -202,7 +201,7 @@ class TestTLSCertificatesOperator:
             .replace(", ", "\n")
             .replace("\\n", "\n")
         )
-        assert formatted_chain == ca_chain.strip("\n")
+        assert formatted_chain == ca_chain_pem.decode("utf-8").strip("\n")
 
 
 async def run_get_certificate_action(ops_test) -> dict:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -168,7 +168,7 @@ class TestTLSCertificatesOperator:
         ca_chain_pem = ca_certificate_pem + certificate_pem
         ca_chain_bytes = base64.b64encode(ca_chain_pem)
 
-        action_output = await run_provide_certificate_action(
+        await run_provide_certificate_action(
             ops_test,
             relation_id=relation.id,
             certificate=certificate_bytes.decode("utf-8"),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -29,7 +29,7 @@ class TestTLSCertificatesOperator:
         return charm
 
     @staticmethod
-    def get_certificate_from_csr(csr: str) -> dict:
+    def get_certificate_and_ca_certificate_from_csr(csr: str) -> dict:
         """Creates a Certificate and a CA certificate from a CSR.
 
         Args:
@@ -168,7 +168,7 @@ class TestTLSCertificatesOperator:
         csr = action_result_list[0]["unit_csrs"][0]["certificate_signing_request"]
         csr_bytes = base64.b64encode(csr.encode("utf-8"))
 
-        certs = self.get_certificate_from_csr(csr)
+        certs = self.get_certificate_and_ca_certificate_from_csr(csr)
         certificate_pem = certs["certificate"].public_bytes(serialization.Encoding.PEM)
         ca_certificate_pem = certs["ca_cert"].public_bytes(serialization.Encoding.PEM)
         certificate_bytes = base64.b64encode(certificate_pem)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -29,12 +29,6 @@ class TestTLSCertificatesOperator:
         return charm
 
     @staticmethod
-    def get_certificate_from_file(filename: str) -> str:
-        with open(filename, "r") as file:
-            certificate = file.read()
-        return certificate
-
-    @staticmethod
     def get_certificate_from_csr(csr: str) -> {}:
         csr_bytes = csr.encode("utf-8")
         csr = x509.load_pem_x509_csr(csr_bytes, default_backend())

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,9 +3,15 @@
 
 import ast
 import base64
+import datetime
 import logging
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 from juju.errors import JujuError
 
 logger = logging.getLogger(__name__)
@@ -27,6 +33,51 @@ class TestTLSCertificatesOperator:
         with open(filename, "r") as file:
             certificate = file.read()
         return certificate
+
+    @staticmethod
+    def get_certificate_from_csr(csr: str) -> {}:
+        csr_bytes = csr.encode("utf-8")
+        csr = x509.load_pem_x509_csr(csr_bytes, default_backend())
+
+        ca_private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+
+        ca_name = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "Example CA"),
+            ]
+        )
+
+        ca_subject = issuer = ca_name
+        ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca_subject)
+            .issuer_name(issuer)
+            .public_key(ca_private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .sign(ca_private_key, hashes.SHA256(), default_backend())
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(csr.subject)
+            .issuer_name(ca_subject)
+            .public_key(csr.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))
+            .sign(ca_private_key, hashes.SHA256(), default_backend())
+        )
+        return {
+            "certificate": cert,
+            "ca_cert": ca_cert,
+        }
 
     @pytest.fixture()
     async def cleanup(self, ops_test):
@@ -109,11 +160,7 @@ class TestTLSCertificatesOperator:
             timeout=1000,
         )
 
-        certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
-        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
         ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
-        certificate_bytes = base64.b64encode(certificate.encode("utf-8"))
-        ca_certificate_bytes = base64.b64encode(ca_certificate.encode("utf-8"))
         ca_chain_bytes = base64.b64encode(ca_chain.encode("utf-8"))
 
         action_output = await run_get_outstanding_csrs_action(ops_test)
@@ -122,7 +169,13 @@ class TestTLSCertificatesOperator:
         csr = action_result_list[0]["unit_csrs"][0]["certificate_signing_request"]
         csr_bytes = base64.b64encode(csr.encode("utf-8"))
 
-        await run_provide_certificate_action(
+        certs = self.get_certificate_from_csr(csr)
+        certificate_pem = certs["certificate"].public_bytes(serialization.Encoding.PEM)
+        ca_certificate_pem = certs["ca_cert"].public_bytes(serialization.Encoding.PEM)
+        certificate_bytes = base64.b64encode(certificate_pem)
+        ca_certificate_bytes = base64.b64encode(ca_certificate_pem)
+
+        action_output = await run_provide_certificate_action(
             ops_test,
             relation_id=relation.id,
             certificate=certificate_bytes.decode("utf-8"),
@@ -138,8 +191,9 @@ class TestTLSCertificatesOperator:
         )
 
         action_output = await run_get_certificate_action(ops_test)
-        assert action_output["certificate"] == certificate.strip("\n")
-        assert action_output["ca-certificate"] == ca_certificate.strip("\n")
+
+        assert action_output["certificate"] == certificate_pem.decode("utf-8").strip("\n")
+        assert action_output["ca-certificate"] == ca_certificate_pem.decode("utf-8").strip("\n")
         formatted_chain = (
             action_output["chain"]
             .replace("[", "")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -29,7 +29,15 @@ class TestTLSCertificatesOperator:
         return charm
 
     @staticmethod
-    def get_certificate_from_csr(csr: str) -> {}:
+    def get_certificate_from_csr(csr: str) -> dict:
+        """Creates a Certificate and a CA certificate from a CSR.
+
+        Args:
+            csr (str): certificate signing request in their original str representation.
+
+        Returns:
+            dict: Containing the Certificate and CA certificate on their x509 object format.
+        """
         csr_bytes = csr.encode("utf-8")
         csr = x509.load_pem_x509_csr(csr_bytes, default_backend())
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,6 +9,10 @@ from ops.model import ActiveStatus
 
 from charm import TLSCertificatesOperatorCharm
 
+TLS_CERTIFICATES_PROVIDES_PATH = (
+    "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2"
+)
+
 
 class TestCharm(unittest.TestCase):
     @staticmethod
@@ -39,9 +43,21 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin()
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.get_requirer_csrs_with_no_certs"  # noqa: E501, W505
-    )
+        csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
+        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
+        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
+        csr = TestCharm._encode_in_base64(csr)
+        certificate_bytes = TestCharm._encode_in_base64(certificate)
+        ca_certificate_bytes = TestCharm._encode_in_base64(ca_certificate)
+        ca_chain_bytes = TestCharm._encode_in_base64(ca_chain)
+
+        self.decoded_csr = TestCharm._decode_from_base64(csr)
+        self.decoded_certificate = TestCharm._decode_from_base64(certificate_bytes)
+        self.decoded_ca_certificate = TestCharm._decode_from_base64(ca_certificate_bytes)
+        self.decoded_ca_chain = TestCharm._decode_from_base64(ca_chain_bytes)
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs_with_no_certs")
     def test_given_outstanding_requests_when_certificate_creation_request_then_status_is_active(
         self, patch_get_requirer_units_csrs_with_no_certs
     ):
@@ -59,56 +75,15 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
         )
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.set_relation_certificate"  # noqa: E501, W505
-    )
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.get_requirer_csrs_with_no_certs"  # noqa: E501, W505
-    )
-    def test_given_one_outstanding_request_when_provide_certificate_then_status_is_active_and_no_outstanding_requests(  # noqa: E501
-        self, patch_get_requirer_units_csrs_with_no_certs, _
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs_with_no_certs")
+    def test_given_no_units_with_no_certs_then_status_is_active_and_no_outstanding_requests(
+        self, patch_get_requirer_units_csrs_with_no_certs
     ):
-        patch_get_requirer_units_csrs_with_no_certs.side_effect = [
-            [
-                {
-                    "relation_id": 1234,
-                    "unit_name": "unit/0",
-                    "application_name": "application",
-                    "unit_csrs": [{"certificate_signing_request": "some csr"}],
-                }
-            ],
-            [],
-        ]
+        patch_get_requirer_units_csrs_with_no_certs.return_value = []
         self.harness.charm._set_active_status(Mock())
-        self.assertEqual(
-            ActiveStatus("1 outstanding requests, use juju actions to provide certificates"),
-            self.harness.charm.unit.status,
-        )
-        self.harness.add_relation("certificates", "requirer")
-        csr = self.get_certificate_from_file(filename="tests/csr.pem")
-        certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
-        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
-        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
-        csr = TestCharm._encode_in_base64(csr)
-        certificate_bytes = TestCharm._encode_in_base64(certificate)
-        ca_certificate_bytes = TestCharm._encode_in_base64(ca_certificate)
-        ca_chain_bytes = TestCharm._encode_in_base64(ca_chain)
+        self.assertEqual(ActiveStatus("No outstanding requests."), self.harness.charm.unit.status)
 
-        event = Mock()
-        event.params = {
-            "certificate-signing-request": TestCharm._decode_from_base64(csr),
-            "certificate": TestCharm._decode_from_base64(certificate_bytes),
-            "ca-certificate": TestCharm._decode_from_base64(ca_certificate_bytes),
-            "ca-chain": TestCharm._decode_from_base64(ca_chain_bytes),
-            "relation-id": 1234,
-        }
-        self.harness.charm._on_provide_certificate_action(event=event)
-        self.assertEqual(
-            ActiveStatus("No outstanding requests."),
-            self.harness.charm.unit.status,
-        )
-
-    def test_given_no_requirer_application_when_get_outstanding_certificate_requests_action_then_empty_list_returned(  # noqa: E501
+    def test_given_no_requirer_application_when_get_outstanding_certificate_requests_action_then_event_fails(  # noqa: E501
         self,
     ):
         event = Mock()
@@ -117,9 +92,7 @@ class TestCharm(unittest.TestCase):
             message="No certificates relation has been created yet."
         )
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.get_requirer_csrs_with_no_certs"  # noqa: E501, W505
-    )
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs_with_no_certs")
     def test_given_requirer_application_when_get_outstanding_certificate_requests_action_then_csrs_information_is_returned(  # noqa: E501
         self, patch_get_requirer_units_csrs_with_no_certs
     ):
@@ -137,6 +110,16 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
         event.set_results.assert_called_once_with({"result": example_unit_csrs})
 
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs_with_no_certs")
+    def test_given_requirer_and_no_outstanding_certs_when_get_outstanding_certificate_requests_action_then_empty_list_is_returned(  # noqa: E501
+        self, patch_get_requirer_units_csrs_with_no_certs
+    ):
+        self.harness.add_relation("certificates", "requirer")
+        patch_get_requirer_units_csrs_with_no_certs.return_value = []
+        event = Mock()
+        self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
+        event.set_results.assert_called_once_with({"result": []})
+
     def test_given_relation_id_not_exist_when_get_outstanding_certificate_requests_action_then_action_returns_empty_list(  # noqa: E501
         self,
     ):
@@ -146,40 +129,26 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
         event.set_results.assert_called_once_with({"result": []})
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.set_relation_certificate"  # noqa: E501, W505
-    )
-    def test_given_valid_input_when_provide_certificate_action_then_certificate_is_provided(
-        self, _
-    ):
-        self.harness.add_relation("certificates", "requirer")
+    def test_given_relation_not_created_when_provide_certificate_action_then_event_fails(self):
         csr = self.get_certificate_from_file(filename="tests/csr.pem")
-        certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
-        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
-        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
         csr = TestCharm._encode_in_base64(csr)
-        certificate_bytes = TestCharm._encode_in_base64(certificate)
-        ca_certificate_bytes = TestCharm._encode_in_base64(ca_certificate)
-        ca_chain_bytes = TestCharm._encode_in_base64(ca_chain)
 
         event = Mock()
         event.params = {
-            "certificate-signing-request": TestCharm._decode_from_base64(csr),
-            "certificate": TestCharm._decode_from_base64(certificate_bytes),
-            "ca-certificate": TestCharm._decode_from_base64(ca_certificate_bytes),
-            "ca-chain": TestCharm._decode_from_base64(ca_chain_bytes),
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
             "relation-id": 1234,
         }
+
         self.harness.charm._on_provide_certificate_action(event=event)
-        event.set_results.assert_called_once_with(
-            {"result": "Certificates successfully provided."}
+        event.fail.assert_called_once_with(
+            message="No certificates relation has been created yet."
         )
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2.set_relation_certificate"  # noqa: E501, W505
-    )
     def test_given_certificate_not_encoded_correctly_when_provide_certificate_action_then_action_fails(  # noqa: E501
-        self, _
+        self,
     ):
         self.harness.add_relation("certificates", "requirer")
         event = Mock()
@@ -192,3 +161,155 @@ class TestCharm(unittest.TestCase):
         }
         self.harness.charm._on_provide_certificate_action(event=event)
         event.fail.assert_called_once_with(message="Action input is not valid.")
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
+    def test_given_csr_does_not_exist_in_requirer_when_provide_certificate_action_then_event_fails(
+        self, patch_get_requirer_csrs
+    ):
+        requirer_app_name = "requirer"
+        relation_id = self.harness.add_relation("certificates", requirer_app_name)
+        csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        csr = TestCharm._encode_in_base64(csr)
+
+        example_unit_csrs = [
+            {
+                "relation_id": relation_id,
+                "application_name": requirer_app_name,
+                "unit_name": f"{requirer_app_name}/0",
+                "unit_csrs": [],
+            }
+        ]
+        patch_get_requirer_csrs.return_value = example_unit_csrs
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
+            "relation-id": relation_id,
+        }
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.fail.assert_called_once_with(
+            message="Certificate signing request was not found in requirer data."
+        )
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
+    def test_given_not_matching_csr_and_certificate_when_provide_certificate_action_then_event_fails(  # noqa: E501
+        self, patch_get_requirer_csrs
+    ):
+        requirer_app_name = "requirer"
+        relation_id = self.harness.add_relation("certificates", requirer_app_name)
+        csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        csr = TestCharm._encode_in_base64(csr)
+        example_unit_csrs = [
+            {
+                "relation_id": relation_id,
+                "application_name": requirer_app_name,
+                "unit_name": f"{requirer_app_name}/0",
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": base64.b64decode(
+                            TestCharm._decode_from_base64(csr)
+                        )
+                        .decode("utf-8")
+                        .strip()
+                    }
+                ],
+            }
+        ]
+        patch_get_requirer_csrs.return_value = example_unit_csrs
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_ca_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
+            "relation-id": relation_id,
+        }
+
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.fail.assert_called_once_with(message="Certificate and CSR do not match.")
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
+    def test_given_valid_input_when_provide_certificate_action_then_certificate_is_provided(
+        self, patch_set_relation_cert, patch_get_requirer_csrs
+    ):
+        requirer_app_name = "requirer"
+        relation_id = self.harness.add_relation("certificates", requirer_app_name)
+        csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        csr = TestCharm._encode_in_base64(csr)
+        example_unit_csrs = [
+            {
+                "relation_id": relation_id,
+                "application_name": requirer_app_name,
+                "unit_name": f"{requirer_app_name}/0",
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": base64.b64decode(
+                            TestCharm._decode_from_base64(csr)
+                        )
+                        .decode("utf-8")
+                        .strip()
+                    }
+                ],
+            }
+        ]
+        patch_get_requirer_csrs.return_value = example_unit_csrs
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
+            "relation-id": relation_id,
+        }
+
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.set_results.assert_called_once_with(
+            {"result": "Certificates successfully provided."}
+        )
+        patch_set_relation_cert.assert_called_once()
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
+    def test_given_runtime_error_during_when_provide_certificate_action_then_event_fails(
+        self, patch_set_relation_cert, patch_get_requirer_csrs
+    ):
+        requirer_app_name = "requirer"
+        relation_id = self.harness.add_relation("certificates", requirer_app_name)
+        csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        csr = TestCharm._encode_in_base64(csr)
+        example_unit_csrs = [
+            {
+                "relation_id": relation_id,
+                "application_name": requirer_app_name,
+                "unit_name": f"{requirer_app_name}/0",
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": base64.b64decode(
+                            TestCharm._decode_from_base64(csr)
+                        )
+                        .decode("utf-8")
+                        .strip()
+                    }
+                ],
+            }
+        ]
+        patch_get_requirer_csrs.return_value = example_unit_csrs
+        patch_set_relation_cert.side_effect = RuntimeError()
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
+            "relation-id": relation_id,
+        }
+
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.fail.assert_called_once_with(message="Relation does not exist with the provided id.")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -259,7 +259,7 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
-    def test_given_runtime_error_during_set_relation_certificate_when_provide_certificate_action_then_event_fails(
+    def test_given_runtime_error_during_set_relation_certificate_when_provide_certificate_action_then_event_fails(  # noqa: E501
         self, patch_set_relation_cert, patch_get_requirer_csrs
     ):
         requirer_app_name = "requirer"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,7 +76,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs_with_no_certs")
-    def test_given_no_units_with_no_certs_then_status_is_active_and_no_outstanding_requests(
+    def test_given_no_units_with_no_certs_when_charm_is_deployed_then_status_is_active_and_no_outstanding_requests(  # noqa: E501
         self, patch_get_requirer_units_csrs_with_no_certs
     ):
         patch_get_requirer_units_csrs_with_no_certs.return_value = []

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,15 +44,15 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
         csr = self.get_certificate_from_file(filename="tests/csr.pem")
+        csr_bytes = TestCharm._encode_in_base64(csr)
         certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
-        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
-        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
-        csr = TestCharm._encode_in_base64(csr)
         certificate_bytes = TestCharm._encode_in_base64(certificate)
+        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
         ca_certificate_bytes = TestCharm._encode_in_base64(ca_certificate)
+        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
         ca_chain_bytes = TestCharm._encode_in_base64(ca_chain)
 
-        self.decoded_csr = TestCharm._decode_from_base64(csr)
+        self.decoded_csr = TestCharm._decode_from_base64(csr_bytes)
         self.decoded_certificate = TestCharm._decode_from_base64(certificate_bytes)
         self.decoded_ca_certificate = TestCharm._decode_from_base64(ca_certificate_bytes)
         self.decoded_ca_chain = TestCharm._decode_from_base64(ca_chain_bytes)
@@ -200,30 +200,22 @@ class TestCharm(unittest.TestCase):
     ):
         requirer_app_name = "requirer"
         relation_id = self.harness.add_relation("certificates", requirer_app_name)
-        csr = self.get_certificate_from_file(filename="tests/csr.pem")
-        csr = TestCharm._encode_in_base64(csr)
+        csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
         example_unit_csrs = [
             {
                 "relation_id": relation_id,
                 "application_name": requirer_app_name,
                 "unit_name": f"{requirer_app_name}/0",
-                "unit_csrs": [
-                    {
-                        "certificate_signing_request": base64.b64decode(
-                            TestCharm._decode_from_base64(csr)
-                        )
-                        .decode("utf-8")
-                        .strip()
-                    }
-                ],
+                "unit_csrs": [{"certificate_signing_request": csr_from_file}],
             }
         ]
         patch_get_requirer_csrs.return_value = example_unit_csrs
+        incorrect_cert = self.decoded_ca_certificate
 
         event = Mock()
         event.params = {
             "certificate-signing-request": self.decoded_csr,
-            "certificate": self.decoded_ca_certificate,
+            "certificate": incorrect_cert,
             "ca-certificate": self.decoded_ca_certificate,
             "ca-chain": self.decoded_ca_chain,
             "relation-id": relation_id,
@@ -239,22 +231,13 @@ class TestCharm(unittest.TestCase):
     ):
         requirer_app_name = "requirer"
         relation_id = self.harness.add_relation("certificates", requirer_app_name)
-        csr = self.get_certificate_from_file(filename="tests/csr.pem")
-        csr = TestCharm._encode_in_base64(csr)
+        csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
         example_unit_csrs = [
             {
                 "relation_id": relation_id,
                 "application_name": requirer_app_name,
                 "unit_name": f"{requirer_app_name}/0",
-                "unit_csrs": [
-                    {
-                        "certificate_signing_request": base64.b64decode(
-                            TestCharm._decode_from_base64(csr)
-                        )
-                        .decode("utf-8")
-                        .strip()
-                    }
-                ],
+                "unit_csrs": [{"certificate_signing_request": csr_from_file}],
             }
         ]
         patch_get_requirer_csrs.return_value = example_unit_csrs
@@ -281,22 +264,13 @@ class TestCharm(unittest.TestCase):
     ):
         requirer_app_name = "requirer"
         relation_id = self.harness.add_relation("certificates", requirer_app_name)
-        csr = self.get_certificate_from_file(filename="tests/csr.pem")
-        csr = TestCharm._encode_in_base64(csr)
+        csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
         example_unit_csrs = [
             {
                 "relation_id": relation_id,
                 "application_name": requirer_app_name,
                 "unit_name": f"{requirer_app_name}/0",
-                "unit_csrs": [
-                    {
-                        "certificate_signing_request": base64.b64decode(
-                            TestCharm._decode_from_base64(csr)
-                        )
-                        .decode("utf-8")
-                        .strip()
-                    }
-                ],
+                "unit_csrs": [{"certificate_signing_request": csr_from_file}],
             }
         ]
         patch_get_requirer_csrs.return_value = example_unit_csrs


### PR DESCRIPTION
# Description

The goal is to add CSR validation to the `provide-certificate` action in the TLS Certificates Operator. 
This PR implements https://github.com/canonical/tls-certificates-operator/issues/59 
If the CSR provided is not found on the `requirer` the action fails.
The validation over the CSR is done using an existing method in the TSL certificates library that compares the CSR and the certificate `public_key` and `subject`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
