### PR TITLE
Validate ca chain

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ from ops.main import main
 from ops.model import ActiveStatus
 
 from helpers import (
+    ca_chain_is_valid,
     certificate_is_valid,
     certificate_signing_request_is_valid,
     parse_ca_chain,
@@ -198,6 +199,8 @@ class TLSCertificatesOperatorCharm(CharmBase):
         for ca in ca_chain_list:
             if not certificate_is_valid(ca.encode()):
                 return False
+        if not ca_chain_is_valid(ca_chain_list):
+            return False
 
         return True
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -8,6 +8,7 @@ import re
 from typing import List
 
 from cryptography import x509
+from cryptography.exceptions import InvalidSignature
 
 
 def certificate_is_valid(certificate: bytes) -> bool:
@@ -65,3 +66,28 @@ def parse_ca_chain(ca_chain_pem: str) -> List[str]:
     if not chain_list:
         raise ValueError("No certificate found in chain file")
     return chain_list
+
+
+def ca_chain_is_valid(ca_chain: List[str]) -> bool:
+    """Returns whether a ca chain is valid.
+
+    It uses the x509 certificate method verify_directly_issued_by.
+    It checks the certificate issuer name matches the issuer subject name and that
+    the certificate is signed by the issuer's private key.
+
+    Args:
+        ca_chain: composed by a list of certificates.
+
+    Returns:
+        whether the ca chain is valid.
+    """
+    if len(ca_chain) < 2:
+        return False
+    for ca_cert, cert in zip(ca_chain, ca_chain[1:]):
+        try:
+            ca_cert_object = x509.load_pem_x509_certificate(ca_cert.encode("utf-8"))
+            cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+            cert_object.verify_directly_issued_by(ca_cert_object)
+        except (ValueError, TypeError, InvalidSignature):
+            return False
+    return True

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -4,11 +4,14 @@
 
 """Methods used to generate self-signed certificates."""
 
+import logging
 import re
 from typing import List
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
+
+logger = logging.getLogger(__name__)
 
 
 def certificate_is_valid(certificate: bytes) -> bool:
@@ -71,8 +74,8 @@ def parse_ca_chain(ca_chain_pem: str) -> List[str]:
 def ca_chain_is_valid(ca_chain: List[str]) -> bool:
     """Returns whether a ca chain is valid.
 
-    It uses the x509 certificate method verify_directly_issued_by.
-    It checks the certificate issuer name matches the issuer subject name and that
+    It uses the x509 certificate method verify_directly_issued_by, which checks
+    the certificate issuer name matches the issuer subject name and that
     the certificate is signed by the issuer's private key.
 
     Args:
@@ -82,12 +85,14 @@ def ca_chain_is_valid(ca_chain: List[str]) -> bool:
         whether the ca chain is valid.
     """
     if len(ca_chain) < 2:
+        logger.warning("Invalid CA chain: It must contain at least 2 certificates.")
         return False
     for ca_cert, cert in zip(ca_chain, ca_chain[1:]):
         try:
             ca_cert_object = x509.load_pem_x509_certificate(ca_cert.encode("utf-8"))
             cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
             cert_object.verify_directly_issued_by(ca_cert_object)
-        except (ValueError, TypeError, InvalidSignature):
+        except (ValueError, TypeError, InvalidSignature) as e:
+            logger.warning("Invalid CA chain: %s", e)
             return False
     return True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -224,16 +224,19 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_provide_certificate_action(event=event)
         event.fail.assert_called_once_with(message="Certificate and CSR do not match.")
 
-    def test_given_invalid_ca_chain_when_provide_certificate_action_then_event_fails(self):
+    @patch("charm.ca_chain_is_valid")
+    def test_given_invalid_ca_chain_when_provide_certificate_action_then_event_fails(
+        self, patch_ca_chain_valid
+    ):
         relation_id = self.harness.add_relation("certificates", "requirer")
-        invalid_ca_chain = self.decoded_ca_certificate
+        patch_ca_chain_valid.return_value = False
 
         event = Mock()
         event.params = {
             "certificate-signing-request": self.decoded_csr,
             "certificate": self.decoded_certificate,
             "ca-certificate": self.decoded_ca_certificate,
-            "ca-chain": invalid_ca_chain,
+            "ca-chain": self.decoded_ca_chain,
             "relation-id": relation_id,
         }
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -224,6 +224,22 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_provide_certificate_action(event=event)
         event.fail.assert_called_once_with(message="Certificate and CSR do not match.")
 
+    def test_given_invalid_ca_chain_when_provide_certificate_action_then_event_fails(self):
+        relation_id = self.harness.add_relation("certificates", "requirer")
+        invalid_ca_chain = self.decoded_ca_certificate
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": invalid_ca_chain,
+            "relation-id": relation_id,
+        }
+
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.fail.assert_called_once_with(message="Action input is not valid.")
+
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
     def test_given_valid_input_when_provide_certificate_action_then_certificate_is_provided(

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
+from typing import List
 
 from helpers import (
     ca_chain_is_valid,
@@ -70,7 +71,7 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(ca_chain_is_valid(ca_chain_list))
 
     def test_given_empty_list_ca_chain_when_ca_chain_is_valid_returns_false(self):
-        ca_chain_list = []
+        ca_chain_list = []  # type: List[str]
         self.assertFalse(ca_chain_is_valid(ca_chain_list))
 
     def test_given_one_certificate_in_ca_chain_when_ca_chain_is_valid_returns_false(self):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -4,6 +4,7 @@
 import unittest
 
 from helpers import (
+    ca_chain_is_valid,
     certificate_is_valid,
     certificate_signing_request_is_valid,
     parse_ca_chain,
@@ -62,3 +63,28 @@ class TestHelpers(unittest.TestCase):
         ca_chain = "Not a CA Chain"
         with self.assertRaises(ValueError):
             parse_ca_chain(ca_chain)
+
+    def test_given_valid_ca_chain_when_ca_chain_is_valid_then_returns_true(self):
+        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
+        ca_chain_list = parse_ca_chain(ca_chain)
+        self.assertTrue(ca_chain_is_valid(ca_chain_list))
+
+    def test_given_empty_list_ca_chain_when_ca_chain_is_valid_returns_false(self):
+        ca_chain_list = []
+        self.assertFalse(ca_chain_is_valid(ca_chain_list))
+
+    def test_given_one_certificate_in_ca_chain_when_ca_chain_is_valid_returns_false(self):
+        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
+        ca_chain_list = parse_ca_chain(ca_chain)[:-1]
+        self.assertFalse(ca_chain_is_valid(ca_chain_list))
+
+    def test_given_invalid_issuer_ca_chain_when_ca_chain_is_valid_returns_false(self):
+        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
+        ca_chain_list = parse_ca_chain(ca_chain)
+        ca_chain_list.reverse()
+        self.assertFalse(ca_chain_is_valid(ca_chain_list))
+
+    def test_given_invalid_certificate_in_ca_chain_when_ca_chain_is_valid_then_returns_false(self):
+        ca_chain = "Not a CA Chain"
+        ca_chain_list = [ca_chain, ca_chain]
+        self.assertFalse(ca_chain_is_valid(ca_chain_list))


### PR DESCRIPTION
# Description

Add validation of the CA chain in the TLS-certificates operator `provide-certificate` action. 
To validate we use the x509 certificate method `verify_directly_issued_by` which checks the certificate issuer name matches the issuer subject name and thatthe certificate is signed by the issuer's private key.

Implements https://github.com/canonical/tls-certificates-operator/issues/58

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
