### PR TITLE
Fix failing integration tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ import binascii
 import logging
 from typing import Dict, List
 
-from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore
+from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import-not-found]  # noqa: E501
     TLSCertificatesProvidesV2,
     csr_matches_certificate,
 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ import binascii
 import logging
 from typing import Dict, List
 
-from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
+from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore
     TLSCertificatesProvidesV2,
     csr_matches_certificate,
 )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -117,12 +117,8 @@ class TestTLSCertificatesOperator:
             application_name=APPLICATION_NAME,
             series="jammy",
         )
-        await ops_test.model.wait_for_idle(
-            apps=[TLS_REQUIRER_CHARM_NAME],
-            status="active",
-            timeout=1000,
-        )
-        await ops_test.model.add_relation(
+
+        await ops_test.model.integrate(
             relation1=APPLICATION_NAME, relation2=TLS_REQUIRER_CHARM_NAME
         )
 
@@ -140,11 +136,6 @@ class TestTLSCertificatesOperator:
             application_name=TLS_REQUIRER_CHARM_NAME,
             channel="edge",
         )
-        await ops_test.model.wait_for_idle(
-            apps=[TLS_REQUIRER_CHARM_NAME],
-            status="active",
-            timeout=1000,
-        )
 
         await ops_test.model.deploy(
             entity_url=charm,
@@ -152,7 +143,7 @@ class TestTLSCertificatesOperator:
             series="jammy",
         )
 
-        relation = await ops_test.model.add_relation(
+        relation = await ops_test.model.integrate(
             relation1=APPLICATION_NAME, relation2=TLS_REQUIRER_CHARM_NAME
         )
 
@@ -186,7 +177,7 @@ class TestTLSCertificatesOperator:
         )
 
         await ops_test.model.wait_for_idle(
-            apps=[TLS_REQUIRER_CHARM_NAME],
+            apps=[APPLICATION_NAME, TLS_REQUIRER_CHARM_NAME],
             status="active",
             timeout=1000,
         )


### PR DESCRIPTION
# Description

Integration tests failed after https://github.com/canonical/tls-certificates-requirer-operator/issues/13 was merged.

`tls-certificates-requirer-operator` status after being deployed is not `active` anymore. 
The check over its status was removed from the integration tests.

Plus minor fix for the static job.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
